### PR TITLE
Expose the IP Address from WiFiManager

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -202,6 +202,16 @@ class ESPSPI_WiFiManager:
         self.pixel_status(0)
         return response_time
 
+    def ip_address(self):
+        """
+        Returns a formatted local IP address, update status pixel.
+        """
+        if not self._esp.is_connected:
+            self.connect()
+        self.pixel_status((0, 0, 100))
+        self.pixel_status(0)
+        return self._esp.pretty_ip(self._esp.ip_address)
+
     def pixel_status(self, value):
         """
         Change Status NeoPixel if it was defined


### PR DESCRIPTION
Exposes the device's IP address from within WiFiManager. 

Calling `print(wifi.ip_address())` returns `10.0.0.000` (snipped to remove identifiers)

Tested on a PyPortal 