### PR TITLE
expose rssi from a method in wifimanager

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -211,3 +211,11 @@ class ESPSPI_WiFiManager:
         """
         if self.statuspix:
             self.statuspix.fill(value)
+
+    def signal_strength(self):
+        """
+        Returns receiving signal strength indicator in dBm
+        """
+        if not self._esp.is_connected:
+            self.connect()
+        return self._esp.rssi()


### PR DESCRIPTION
Addressing https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/issues/15

Exposing RSSI for the access point we're connected to as `wifi.signal_strength`