### PR TITLE
 add retry to AP connect for simpletest

### DIFF
--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -28,7 +28,12 @@ for ap in esp.scan_networks():
     print("\t%s\t\tRSSI: %d" % (str(ap['ssid'], 'utf-8'), ap['rssi']))
 
 print("Connecting to AP...")
-esp.connect_AP(b'MY_SSID_NAME', b'MY_SSID_PASSWORD')
+while not esp.is_connected:
+    try:
+        esp.connect_AP(b'MY_SSID_NAME', b'MY_SSID_PASSWORD')
+    except RuntimeError as e:
+        print("could not connect to AP, retrying: ",e)
+        continue
 print("Connected to", str(esp.ssid, 'utf-8'), "\tRSSI:", esp.rssi)
 print("My IP address is", esp.pretty_ip(esp.ip_address))
 print("IP lookup adafruit.com: %s" % esp.pretty_ip(esp.get_host_by_name("adafruit.com")))
@@ -51,3 +56,4 @@ print('-'*40)
 r.close()
 
 print("Done!")
+

--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -56,4 +56,3 @@ print('-'*40)
 r.close()
 
 print("Done!")
-


### PR DESCRIPTION
I find that the first attempt to connect to my SSID  often fails. It usually connects on the secontd try.
adding this retry loop avoids a lot of problems.
This just occurred when I tried following the guide for a new pyportal.
With this change, it connects reliably.