### PR TITLE
Changed Default Timezone to String because Int breaks PyPortal

### DIFF
--- a/examples/esp32spi_secrets.py
+++ b/examples/esp32spi_secrets.py
@@ -4,7 +4,7 @@
 secrets = {
     'ssid' : 'yourssid',
     'password' : 'yourpassword',
-    'timezone' : -5, # this is offset from UTC
+    'timezone' : "America/New_York", # Check http://worldtimeapi.org/timezones
     'aio_username' : 'youraiousername',
     'aio_key' : 'youraiokey',
 }


### PR DESCRIPTION
It was a -5 which is currently causing PyPortal to crash. It really should be fixed in PyPortal, but this should stop this from being a breaking issue.