### PR TITLE
Encode HTTP request header string components as (ASCII) bytes.

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_requests.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_requests.py
@@ -173,9 +173,9 @@ def request(method, url, data=None, json=None, headers=None, stream=False):
             sock.write(b"User-Agent: Adafruit CircuitPython\r\n")
         # Iterate over keys to avoid tuple alloc
         for k in headers:
-            sock.write(k)
+            sock.write(k.encode())
             sock.write(b": ")
-            sock.write(headers[k])
+            sock.write(headers[k].encode())
             sock.write(b"\r\n")
         if json is not None:
             assert data is None


### PR DESCRIPTION
Client app code (previously crashed with `TypeError: can't convert str to int` in line 176), e.g.:
```
custom_headers = {"X-Moose" : "Bullwinkle",  "X-Squirrel" : "Rocky", }
response = wifi.get("https://example.com/", data=None, json=None, headers=custom_headers, stream=False)
```
Now results in request headers received by the remote server, e.g.:
```
HTTP_X_MOOSE: Bullwinkle
HTTP_X_SQUIRREL: Rocky
```
(Note: headers are case-insensitive and capitalization varies between server environments.)