### PR TITLE
Fix "Host" and "User-Agent" overrides in request()

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_requests.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_requests.py
@@ -167,9 +167,9 @@ def request(method, url, data=None, json=None, headers=None, stream=False):
             conntype = _the_interface.TCP_MODE
             sock.connect(addr_info[-1], conntype)
         sock.write(b"%s /%s HTTP/1.0\r\n" % (method, path))
-        if "Host" not in headers:
+        if b"Host" not in headers:
             sock.write(b"Host: %s\r\n" % host)
-        if "User-Agent" not in headers:
+        if b"User-Agent" not in headers:
             sock.write(b"User-Agent: Adafruit CircuitPython\r\n")
         # Iterate over keys to avoid tuple alloc
         for k in headers:


### PR DESCRIPTION
In my testing I discovered a "b" is needed in front of the "Host" (line 170) and "User-Agent" (line 172) strings for proper comparison when using request() and sending something like headers={bytes("User-Agent","utf-8"):bytes("Mozilla Clone","utf-8")}