### PR TITLE
Fixed infinite loop when socket readline fails

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -91,7 +91,7 @@ class socket:
             avail = min(_the_interface.socket_available(self._socknum), MAX_PACKET)
             if avail:
                 self._buffer += _the_interface.socket_read(self._socknum, avail)
-            elif time.monotonic() - stamp > self._timeout:
+            elif self._timeout > 0 and time.monotonic() - stamp > self._timeout:
                 self.close()  # Make sure to close socket so that we don't exhaust sockets.
                 raise RuntimeError("Didn't receive full response, failing out")
         firstline, self._buffer = self._buffer.split(b'\r\n', 1)

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -85,11 +85,15 @@ class socket:
     def readline(self):
         """Attempt to return as many bytes as we can up to but not including '\r\n'"""
         #print("Socket readline")
+        stamp = time.monotonic()
         while b'\r\n' not in self._buffer:
             # there's no line already in there, read some more
             avail = min(_the_interface.socket_available(self._socknum), MAX_PACKET)
             if avail:
                 self._buffer += _the_interface.socket_read(self._socknum, avail)
+            elif time.monotonic() - stamp > self._timeout:
+                self.close()  # Make sure to close socket so that we don't exhaust sockets.
+                raise RuntimeError("Didn't receive full response, failing out")
         firstline, self._buffer = self._buffer.split(b'\r\n', 1)
         gc.collect()
         return firstline


### PR DESCRIPTION
In certain cases, the socket may not receive a full response (or any
response), causing the while loop in readline to go on forever. After
failing to receive any data, this fix will raise an exception and fail
out.

Mitigates #11 