### PR TITLE
Fix zero timeout in socket, add configurable timeout to ESP_SPIcontrol

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -73,6 +73,8 @@ class socket:
         a hostname string). 'conntype' is an extra that may indicate SSL or not,
         depending on the underlying interface"""
         host, port = address
+        if conntype is None:
+            conntype = _the_interface.TCP_MODE
         if not _the_interface.socket_connect(self._socknum, host, port, conn_mode=conntype):
             raise RuntimeError("Failed to connect to host", host)
         self._buffer = b''
@@ -123,7 +125,7 @@ class socket:
                 received.append(recv)
                 to_read -= len(recv)
                 gc.collect()
-            if time.monotonic() - stamp > self._timeout:
+            if self._timeout > 0 and time.monotonic() - stamp > self._timeout:
                 break
         #print(received)
         self._buffer += b''.join(received)


### PR DESCRIPTION
- This fixes a bug where a zero timeout in socket would not block as documented.

- Adds a configurable timeout to ESP_SPIcontrol.  Some SSL sites took longer than 10 seconds to complete the SSL handshake and the communication with the ESP32 timed out.  Increasing the timeout to 12 seconds resolves the problem described in https://github.com/arduino/nina-fw/issues/10

- Handle missing optional conntype parameter in socket.connect.
