### PR TITLE
Add RGB Status LED to WiFiManager

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -55,9 +55,6 @@ class ESPSPI_WiFiManager:
         self.attempts = attempts
         requests.set_interface(self._esp)
         self.statuspix = status_pixel
-        self._is_rgb_led = False
-        if hasattr(self.statuspix, 'color'):
-            self._is_rgb_led = True
         self.pixel_status(0)
 
     def reset(self):
@@ -218,15 +215,16 @@ class ESPSPI_WiFiManager:
 
     def pixel_status(self, value):
         """
-        Change Status NeoPixel/Dotstar/RGBLED if it was defined
+        Change Status Pixel if it was defined
 
         :param value: The value to set the Board's status LED to
         :type value: int or 3-value tuple
         """
-        if self.statuspix and not self._is_rgb_led:
-            self.statuspix.fill(value)
-        else:
-            self.statuspix.color = value
+        if self.statuspix:
+            if hasattr(self.statuspix, 'color'):
+                self.statuspix.color = value
+            else:
+                self.statuspix.fill(value)
 
     def signal_strength(self):
         """

--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -42,8 +42,9 @@ class ESPSPI_WiFiManager:
         """
         :param ESP_SPIcontrol esp: The ESP object we are using
         :param dict secrets: The WiFi and Adafruit IO secrets dict (See examples)
-        :param status_pixel: (Optional) The pixel device - A NeoPixel or DotStar (default=None)
-        :type status_pixel: NeoPixel or DotStar
+        :param status_pixel: (Optional) The pixel device - A NeoPixel, DotStar,
+            or RGB LED (default=None)
+        :type status_pixel: NeoPixel, DotStar, or RGB LED
         :param int attempts: (Optional) Failed attempts before resetting the ESP32 (default=2)
         """
         # Read the settings
@@ -54,6 +55,9 @@ class ESPSPI_WiFiManager:
         self.attempts = attempts
         requests.set_interface(self._esp)
         self.statuspix = status_pixel
+        self._is_rgb_led = False
+        if hasattr(self.statuspix, 'color'):
+            self._is_rgb_led = True
         self.pixel_status(0)
 
     def reset(self):
@@ -214,13 +218,15 @@ class ESPSPI_WiFiManager:
 
     def pixel_status(self, value):
         """
-        Change Status NeoPixel if it was defined
+        Change Status NeoPixel/Dotstar/RGBLED if it was defined
 
         :param value: The value to set the Board's status LED to
         :type value: int or 3-value tuple
         """
-        if self.statuspix:
+        if self.statuspix and not self._is_rgb_led:
             self.statuspix.fill(value)
+        else:
+            self.statuspix.color = value
 
     def signal_strength(self):
         """

--- a/examples/esp32spi_aio_post.py
+++ b/examples/esp32spi_aio_post.py
@@ -30,7 +30,14 @@ esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 """Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
-#status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+# status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
+# Uncomment below for an externally defined RGB LED
+# import adafruit_rgbled
+# from adafruit_esp32spi import PWMOut
+# RED_LED = PWMOut.PWMOut(esp, 26)
+# GREEN_LED = PWMOut.PWMOut(esp, 27)
+# BLUE_LED = PWMOut.PWMOut(esp, 25)
+# status_light = adafruit_rgbled.RGBLED(RED_LED, BLUE_LED, GREEN_LED)
 wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
 
 counter = 0


### PR DESCRIPTION

This pull request adds the option of using an externally defined RGB LED (https://github.com/adafruit/Adafruit_CircuitPython_RGBLED) as a `status_pixel` for `WiFiManager`. Useful for AirLift Breakout and FeatherWing.

* `pixel_status` has been modified to set `color` based on LED type.
*  Modified `examples/esp32spi_aio_post.py` to show usage for a RGB LED.

Tested with Feather M4 on CircuitPython 4.0.1, AirLift FeatherWing. Tested both constructing and passing `wifi` an RGB LED `status_pixel` and a NeoPixel `status_pixel`. 

Addressing https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/issues/47

