### PR TITLE
Add Server functionality

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -66,6 +66,7 @@ _GET_CURR_RSSI_CMD     = const(0x25)
 _GET_CURR_ENCT_CMD     = const(0x26)
 
 _SCAN_NETWORKS         = const(0x27)
+_START_SERVER_TCP_CMD  = const(0x28)
 _GET_SOCKET_CMD        = const(0x3F)
 _GET_STATE_TCP_CMD     = const(0x29)
 _DATA_SENT_TCP_CMD     = const(0x2A)
@@ -661,6 +662,25 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
         resp = self._send_command_get_response(_STOP_CLIENT_TCP_CMD, self._socknum_ll)
         if resp[0][0] != 1:
             raise RuntimeError("Failed to close socket")
+
+    def start_server(self, port, socket_num, conn_mode=TCP_MODE, ip=None):
+        if self._debug:
+            print("*** starting server")
+        self._socknum_ll[0][0] = socket_num
+        port_param = struct.pack('>H', port)
+        if ip:      # use the 4 arg version
+            resp = self._send_command_get_response(_START_SERVER_TCP_CMD,
+                                                    (ip,
+                                                    port_param,
+                                                    self._socknum_ll[0],
+                                                    (conn_mode,)))
+        else:       # use the 3 arg version
+            resp = self._send_command_get_response(_START_SERVER_TCP_CMD,
+                                                (port_param,
+                                                self._socknum_ll[0],
+                                                (conn_mode,)))
+        if resp[0][0] != 1:
+            raise RuntimeError("Could not start server")
 
     def set_esp_debug(self, enabled):
         """Enable/disable debug mode on the ESP32. Debug messages will be

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -682,6 +682,11 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
         if resp[0][0] != 1:
             raise RuntimeError("Could not start server")
 
+    def get_server_state(self, socket_num):
+        self._socknum_ll[0][0] = socket_num
+        resp = self._send_command_get_response(_GET_STATE_TCP_CMD, self._socknum_ll)
+        return resp[0][0]
+
     def set_esp_debug(self, enabled):
         """Enable/disable debug mode on the ESP32. Debug messages will be
         written to the ESP32's UART."""

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -54,7 +54,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI.git"
 # pylint: disable=bad-whitespace
 _SET_NET_CMD           = const(0x10)
 _SET_PASSPHRASE_CMD    = const(0x11)
-_SET_AP_NET_CMD		   = const(0x18)
+_SET_AP_NET_CMD        = const(0x18)
 _SET_AP_PASSPHRASE_CMD = const(0x19)
 _SET_DEBUG_CMD         = const(0x1A)
 

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -416,13 +416,14 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
         resp = self._send_command_get_response(_SET_AP_NET_CMD, [ssid, channel])
         if resp[0][0] != 1:
             raise RuntimeError("Failed to setup AP network")
-    
+
     def wifi_set_ap_passphrase(self, ssid, passphrase, channel):
         """TODO Docs"""
+        """ TODO: Why does this command refuse to work? creating AP w/out password works fine"""
         resp = self._send_command_get_response(_SET_AP_PASSPHRASE_CMD, [ssid, passphrase, channel])
         if resp[0][0] != 1:
-            raise RuntimeError("Failed to setup AP network")
-    
+            raise RuntimeError("Failed to setup AP password")
+
     @property
     def ssid(self):
         """The name of the access point we're connected to"""
@@ -496,7 +497,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
             raise RuntimeError("No such ssid", ssid)
         raise RuntimeError("Unknown error 0x%02X" % stat)
 
-    def create_AP(self, ssid, password, channel=1):
+    def create_AP(self, ssid, password, channel=b'\x01'):
         """Create an access point with the given name and password."""
         if isinstance(ssid, str):
             ssid = bytes(ssid, 'utf-8')

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -66,6 +66,7 @@ class socket:
             raise RuntimeError("Only SOCK_STREAM type supported")
         self._buffer = b''
         self._socknum = _the_interface.get_socket()
+        print("socknum: ", self._socknum)
         self.settimeout(0)
 
     def connect(self, address, conntype=None):
@@ -147,6 +148,9 @@ class socket:
     def settimeout(self, value):
         """Set the read timeout for sockets, if value is 0 it will block"""
         self._timeout = value
+
+    def get_sock_num(self):
+        return self._socknum
 
     def close(self):
         """Close the socket, after reading whatever remains"""

--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -31,8 +31,9 @@ WiFi Manager for making ESP32 SPI as WiFi much easier
 
 # pylint: disable=no-name-in-module
 
-from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_esp32spi.adafruit_esp32spi_requests as requests
+from adafruit_esp32spi import adafruit_esp32spi
+
 
 class ESPSPI_WiFiManager:
     """
@@ -87,6 +88,27 @@ class ESPSPI_WiFiManager:
                 self.pixel_status((0, 100, 0))
             except (ValueError, RuntimeError) as error:
                 print("Failed to connect, retrying\n", error)
+                failure_count += 1
+                if failure_count >= self.attempts:
+                    failure_count = 0
+                    self.reset()
+                continue
+
+    def create_ap(self):
+        """
+        Attempt to initialize in Access Point (AP) mode.
+        Other WiFi devices will be able to connect to the created Access Point
+        """
+        while not self._esp.ap_listening:
+            try:
+                if self.debug:
+                    print("Waiting for AP to be initialized...")
+                self.pixel_status((100,0,0))
+                self._esp.create_AP(bytes.ssid, 'utf-8'), bytes(self.password, 'utf-8')
+                failure_count = 0
+                self.pixel_status((0,100,0))
+            except (ValueError, RuntimeError) as error:
+                print("Failed to create access point\n", error)
                 failure_count += 1
                 if failure_count >= self.attempts:
                     failure_count = 0

--- a/examples/esp32spi_server.py
+++ b/examples/esp32spi_server.py
@@ -1,0 +1,24 @@
+import board
+import busio
+from digitalio import DigitalInOut
+from secrets import secrets
+
+from adafruit_esp32spi import adafruit_esp32spi
+import adafruit_esp32spi.adafruit_esp32spi_requests as requests
+import adafruit_esp32spi.adafruit_esp32spi_wifimanager as wifimanager
+
+print("ESP32 SPI web server test!!!!!!")
+
+esp32_cs = DigitalInOut(board.D10)
+esp32_ready = DigitalInOut(board.D9)
+esp32_reset = DigitalInOut(board.D7)
+
+
+spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, debug=True)
+
+wifi = wifimanager.ESPSPI_WiFiManager(esp, secrets, debug=True)
+
+wifi.create_ap();
+
+print("done!")

--- a/examples/esp32spi_server.py
+++ b/examples/esp32spi_server.py
@@ -6,6 +6,7 @@ from secrets import secrets
 from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_esp32spi.adafruit_esp32spi_requests as requests
 import adafruit_esp32spi.adafruit_esp32spi_wifimanager as wifimanager
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
 print("ESP32 SPI web server test!!!!!!")
 
@@ -19,6 +20,30 @@ esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, 
 
 wifi = wifimanager.ESPSPI_WiFiManager(esp, secrets, debug=True)
 
-wifi.create_ap();
+wifi.create_ap()
+time.sleep(10)
+
+sock = socket.socket() # gets and creates a socket
+sock_num = sock.get_sock_num() # returns socket number
+
+esp.start_server(sock_num, 80)
+print("socket num: ", sock_num)
+print("socket status?: ", esp.socket_status(sock_num))
+print("IP addr: ", esp.pretty_ip(esp.ip_address))
+
+status = 0
+while True:
+    if status != esp.status:
+        status = esp.status
+
+        if status == 8:
+            print("Device connected!") ## works
+        else:
+            print("Device disconnected status=", status) ## works
+
+    print("socket available?: ", esp.socket_available(sockNum))
+    print("socket_status: ", esp.socket_status(sockNum))
+    print(sock.read())
+
 
 print("done!")

--- a/examples/esp32spi_server.py
+++ b/examples/esp32spi_server.py
@@ -1,5 +1,6 @@
 import board
 import busio
+import time
 from digitalio import DigitalInOut
 from secrets import secrets
 
@@ -13,37 +14,73 @@ print("ESP32 SPI web server test!!!!!!")
 esp32_cs = DigitalInOut(board.D10)
 esp32_ready = DigitalInOut(board.D9)
 esp32_reset = DigitalInOut(board.D7)
+esp32_gpio0 = DigitalInOut(board.D12)
 
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
-esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, debug=True)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset, gpio0_pin=esp32_gpio0, debug=False)
 
+## Create Access Point from SSID and optional password in secrets
 wifi = wifimanager.ESPSPI_WiFiManager(esp, secrets, debug=True)
-
 wifi.create_ap()
 time.sleep(10)
 
-sock = socket.socket() # gets and creates a socket
-sock_num = sock.get_sock_num() # returns socket number
+socket.set_interface(esp)
+sock = socket.socket() # Request a socket for the server
+curr_sock = sock
+sockNum = sock.get_sock_num()
+print("server status: ", esp.get_server_state(sockNum))
 
-esp.start_server(sock_num, 80)
-print("socket num: ", sock_num)
-print("socket status?: ", esp.socket_status(sock_num))
+# Start the server on port 80 with the socket number we just requested for it.
+esp.start_server(80, sockNum)
+
+print("socket num: ", sockNum)
+print("server status: ", esp.get_server_state(sockNum))
 print("IP addr: ", esp.pretty_ip(esp.ip_address))
+print("info: ", esp.network_data)
+print("done!")
+
 
 status = 0
+last_sock = 255
+def server_avail(): # TODO: make a server helper class
+    global last_sock
+    sock = 255;
+
+    if (curr_sock != 255):
+        # if (last_sock != 255):
+        #       TODO: if last sock, check that last_sock is still connected and available
+        #     sock = last_sock
+        if (sock == 255):
+            sock = esp.socket_available(sockNum)
+    if (sock != 255):
+        last_sock = sock
+        return sock
+
+    return 255
+
 while True:
-    if status != esp.status:
+    if status != esp.status: # TODO: Move device connected check to server class ?
         status = esp.status
 
         if status == 8:
-            print("Device connected!") ## works
+            print("Device connected! status=", status)
         else:
-            print("Device disconnected status=", status) ## works
-
-    print("socket available?: ", esp.socket_available(sockNum))
-    print("socket_status: ", esp.socket_status(sockNum))
-    print(sock.read())
+            print("Device disconnected! status=", status)
 
 
-print("done!")
+    avail = server_avail()
+    if (avail != 255):
+        sock.set_sock_num(avail) # TODO: Server class should return a new client socket
+        data = sock.read()
+        if (len(data)):
+            print(data)
+            sock.write(b"HTTP/1.1 200 OK\r\n");
+            sock.write(b"Content-type:text/html\r\n");
+            sock.write(b"\r\n");
+
+            sock.write(b"Click <a href=\"/H\">here</a> turn the LED on!!!<br>\r\n");
+            sock.write(b"Click <a href=\"/L\">here</a> turn the LED off!!!!<br>\r\n");
+
+            sock.write(b"\r\n")
+            sock.close()


### PR DESCRIPTION
This is still a work in progress, but opening it up for early feedback and suggestions.


- Adds Server creation methods to esp32spi.py
  - Instantiates a server on the esp32 on the specified port and a specified socket that was previously requested
- Adds a new example file that creates an access point from secrets.py and then a server on port 80
  - Logs when a device connects or disconnects from the access point
  - When a device hits `<serverIP>:80` (like in their browser), send back simple HTML page that has a couple of anchor tags on it

### Todo
- [ ] rebase with master once #57 is merged
- [ ] Make the example code more polished and more fun. 
- [ ] Create a new helper class to manage server creation and management. 
- [ ] Thinking we could even go so far as to implement simple request handling. Something like:
   ```
      Server.on("<HttpMethod>", "</routeString>", callbackFn)
      ... 
      def callbackFn(data, socketToWriteTo):
   ```
   - This Might be confusing since the run loop would need to be handled outside code.py?
   - At the very least could have a method to check *if* a certain route is triggered?
   - Could instead have a more feature rich web server lib (like flask) live outside of this to keep it focused.
- [ ] More cleanup
- [ ] More testing
- [ ] Fix linting errors + get green build