### PR TITLE
Fixed MAC reverse byte order issue.

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -337,7 +337,9 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
         if self._debug:
             print("MAC address")
         resp = self._send_command_get_response(_GET_MACADDR_CMD, [b'\xFF'])
-        return resp[0]
+        new_resp = bytearray(resp[0])
+        new_resp = reversed(new_resp)
+        return new_resp
 
     def start_scan_networks(self):
         """Begin a scan of visible access points. Follow up with a call

--- a/examples/server/esp32spi_wsgiserver.py
+++ b/examples/server/esp32spi_wsgiserver.py
@@ -8,6 +8,9 @@ from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_esp32spi.adafruit_esp32spi_wifimanager as wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_wsgiserver as server
 
+
+
+
 # This example depends on the 'static' folder in the examples folder
 # being copied to the root of the circuitpython filesystem.
 # This is where our static assets like html, js, and css live.
@@ -38,6 +41,8 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset) # pylint: disable=line-too-long
+
+print("MAC addr:", [hex(i) for i in esp.MAC_address])
 
 """Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards

--- a/examples/server/esp32spi_wsgiserver.py
+++ b/examples/server/esp32spi_wsgiserver.py
@@ -8,9 +8,6 @@ from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_esp32spi.adafruit_esp32spi_wifimanager as wifimanager
 import adafruit_esp32spi.adafruit_esp32spi_wsgiserver as server
 
-
-
-
 # This example depends on the 'static' folder in the examples folder
 # being copied to the root of the circuitpython filesystem.
 # This is where our static assets like html, js, and css live.


### PR DESCRIPTION
Fixed MAC reverse byte order issue within the ESP32SPI library as it was originally reporting the MAC address in reverse byte order. Added portable MAC function call within WSGISERVER.PY example to properly echo MAC address when running example.