### PR TITLE
Fixed MAC reverse byte order issue within the ESP32SPI library as it …

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -341,7 +341,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
 
     @property
     def MAC_address_actual(self):        # pylint: disable=invalid-name
-        """A bytearray containing the MAC address of the ESP32"""
+        """A bytearray containing the actual MAC address of the ESP32"""
         if self._debug:
             print("MAC address")
         resp = self._send_command_get_response(_GET_MACADDR_CMD, [b'\xFF'])
@@ -770,4 +770,3 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
                                                ((pin,), (value,)))
         if resp[0][0] != 1:
             raise RuntimeError("Failed to write to pin")
-            

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -337,6 +337,14 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
         if self._debug:
             print("MAC address")
         resp = self._send_command_get_response(_GET_MACADDR_CMD, [b'\xFF'])
+        return resp[0]
+
+    @property
+    def MAC_address_actual(self):        # pylint: disable=invalid-name
+        """A bytearray containing the MAC address of the ESP32"""
+        if self._debug:
+            print("MAC address")
+        resp = self._send_command_get_response(_GET_MACADDR_CMD, [b'\xFF'])
         new_resp = bytearray(resp[0])
         new_resp = reversed(new_resp)
         return new_resp
@@ -762,4 +770,3 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
                                                ((pin,), (value,)))
         if resp[0][0] != 1:
             raise RuntimeError("Failed to write to pin")
-            

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -337,7 +337,9 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
         if self._debug:
             print("MAC address")
         resp = self._send_command_get_response(_GET_MACADDR_CMD, [b'\xFF'])
-        return resp[0]
+        new_resp = bytearray(resp[0])
+        new_resp = reversed(new_resp)
+        return new_resp
 
     def start_scan_networks(self):
         """Begin a scan of visible access points. Follow up with a call

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -762,3 +762,4 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
                                                ((pin,), (value,)))
         if resp[0][0] != 1:
             raise RuntimeError("Failed to write to pin")
+            

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -770,3 +770,4 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
                                                ((pin,), (value,)))
         if resp[0][0] != 1:
             raise RuntimeError("Failed to write to pin")
+            

--- a/examples/server/esp32spi_wsgiserver.py
+++ b/examples/server/esp32spi_wsgiserver.py
@@ -215,3 +215,4 @@ while True:
         print("Failed to update server, restarting ESP32\n", e)
         wifi.reset()
         continue
+        

--- a/examples/server/esp32spi_wsgiserver.py
+++ b/examples/server/esp32spi_wsgiserver.py
@@ -40,6 +40,7 @@ spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset) # pylint: disable=line-too-long
 
 print("MAC addr:", [hex(i) for i in esp.MAC_address])
+print("MAC addr actual:", [hex(i) for i in esp.MAC_address_actual])
 
 """Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
@@ -215,4 +216,3 @@ while True:
         print("Failed to update server, restarting ESP32\n", e)
         wifi.reset()
         continue
-        

--- a/examples/server/esp32spi_wsgiserver.py
+++ b/examples/server/esp32spi_wsgiserver.py
@@ -39,6 +39,8 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset) # pylint: disable=line-too-long
 
+print("MAC addr:", [hex(i) for i in esp.MAC_address])
+
 """Use below for Most Boards"""
 status_light = neopixel.NeoPixel(board.NEOPIXEL, 1, brightness=0.2) # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""

--- a/examples/server/esp32spi_wsgiserver.py
+++ b/examples/server/esp32spi_wsgiserver.py
@@ -216,3 +216,4 @@ while True:
         print("Failed to update server, restarting ESP32\n", e)
         wifi.reset()
         continue
+        


### PR DESCRIPTION
…was originally echoing the MAC address in reverse byte order.  Added portable MAC function call within WSGISERVER.PY example to properly echo MAC address when running example.