### PR TITLE
raise AP specific error when trying to get_time while in AP mode

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -764,7 +764,9 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
 
     def get_time(self):
         """The current unix timestamp"""
-        if self.status == 3:
+        if self.status == WL_CONNECTED:
             resp = self._send_command_get_response(_GET_TIME)
             return struct.unpack('<i', resp[0])
+        if self.status in (WL_AP_LISTENING, WL_AP_CONNECTED):
+            raise RuntimeError("Cannot obtain NTP while in AP mode, must be connected to internet")
         raise RuntimeError("Must be connected to WiFi before obtaining NTP.")


### PR DESCRIPTION
We would have already been correctly raising an error when trying to get_time if we were in AP mode instead of connected to WiFi.

This change just adds a more targeted error message if we detect you are in AP mode and trying to get_time