### PR TITLE
Use socket.recv instead of socket.read

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -111,11 +111,12 @@ class socket:
         gc.collect()
         return firstline
 
-    def read(self, size=0):
-        """Read up to 'size' bytes from the socket, this may be buffered internally!
-        If 'size' isnt specified, return everything in the buffer."""
-        #print("Socket read", size)
-        if size == 0:   # read as much as we can at the moment
+    def recv(self, bufsize=0):
+        """Reads some bytes from the connected remote address.
+        :param int bufsize: maximum number of bytes to receive
+        """
+        #print("Socket read", bufsize)
+        if bufsize == 0:   # read as much as we can at the moment
             while True:
                 avail = self.available()
                 if avail:
@@ -129,7 +130,7 @@ class socket:
             return ret
         stamp = time.monotonic()
 
-        to_read = size - len(self._buffer)
+        to_read = bufsize - len(self._buffer)
         received = []
         while to_read > 0:
             #print("Bytes to read:", to_read)
@@ -146,14 +147,21 @@ class socket:
         self._buffer += b''.join(received)
 
         ret = None
-        if len(self._buffer) == size:
+        if len(self._buffer) == bufsize:
             ret = self._buffer
             self._buffer = b''
         else:
-            ret = self._buffer[:size]
-            self._buffer = self._buffer[size:]
+            ret = self._buffer[:bufsize]
+            self._buffer = self._buffer[bufsize:]
         gc.collect()
         return ret
+
+    def read(self, size=0):
+        """Read up to 'size' bytes from the socket, this may be buffered internally!
+        If 'size' isnt specified, return everything in the buffer.
+        NOTE: This method is deprecated and will be removed.
+        """
+        return self.recv(size)
 
     def settimeout(self, value):
         """Set the read timeout for sockets, if value is 0 it will block"""


### PR DESCRIPTION
Switching `socket.read` to `socket.recv` to match the [CircuitPython Socket API](https://circuitpython.readthedocs.io/en/latest/shared-bindings/socket/__init__.html#socket.recv) and the [CPython Socket API](https://docs.python.org/3/library/socket.html#socket.socket.recv).

* `read` now calls `recv`, has a note regarding future depreciation 

MiniMQTT and Requests are affected by this change.

Tested on: `Adafruit CircuitPython 4.0.2 on 2019-06-27; Adafruit PyPortal with samd51j20`

Tests ran:
`esp32spi_simpletest.py` - ESP + Requests
```
Ping google.com: 10 ms
Fetching text from http://wifitest.adafruit.com/testwifi/index.html
----------------------------------------
This is a test of Adafruit WiFi!
If you can read this, its working :)

----------------------------------------

Fetching json from http://api.coindesk.com/v1/bpi/currentprice/USD.json
----------------------------------------
{'time': {'updated': 'Aug 29, 2019 21:35:00 UTC', 'updatedISO': '2019-08-29T21:35:00+00:00', 'updateduk': 'Aug 29, 2019 at 22:35 BST'}, 'disclaimer': 'This data was produced from the CoinDesk Bitcoin Price Index (USD). Non-USD currency data converted using hourly conversion rate from openexchangerates.org', 'bpi': {'USD': {'code': 'USD', 'description': 'United States Dollar', 'rate_float': 9513.59, 'rate': '9,513.5900'}}}
----------------------------------------
Done!
```

`esp32spi_aio_post.py` - WiFiManager + Requests
```
ESP32 SPI webclient test
Posting data...{'lat': None, 'feed_id': 997503, 'ele': None, 'expiration': '2019-10-28T21:36:43Z', 'id': '0E82WHFFNKECTNQ5JZP2DVH7C8', 'lon': None, 'value': '0', 'feed_key': 'test', 'location': None, 'created_at': '2019-08-29T21:36:43Z', 'created_epoch': 1567114603}
OK
Posting data...{'lat': None, 'feed_id': 997503, 'ele': None, 'expiration': '2019-10-28T21:37:02Z', 'id': '0E82WHN3B7J3DMSETJ1Y0QWRMZ', 'lon': None, 'value': '1', 'feed_key': 'test', 'location': None, 'created_at': '2019-08-29T21:37:02Z', 'created_epoch': 1567114622}
OK
```

MiniMQTT Adafruit IO Example
```
code.py output:
Connecting to Adafruit IO...
Connected to Adafruit IO! Listening for topic changes on snip/feeds/onoff
Sending photocell value: 0...
Sent!
Sending photocell value: 1...
Sent!
Sending photocell value: 2...
Sent!
Sending photocell value: 3...
Sent!
Sending photocell value: 4...
Sent!
Sending photocell value: 5...
Sent!
```