### PR TITLE
 raise error in get_time if zero returned

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -766,9 +766,10 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
         """The current unix timestamp"""
         if self.status == WL_CONNECTED:
             resp = self._send_command_get_response(_GET_TIME)
-            if struct.unpack('<i', resp[0]) == (0,):
+            resp_time = struct.unpack('<i', resp[0])
+            if resp_time == (0,):
                 raise ValueError("_GET_TIME returned 0")
-            return struct.unpack('<i', resp[0])
+            return resp_time
         if self.status in (WL_AP_LISTENING, WL_AP_CONNECTED):
             raise RuntimeError("Cannot obtain NTP while in AP mode, must be connected to internet")
         raise RuntimeError("Must be connected to WiFi before obtaining NTP.")

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -766,6 +766,8 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods
         """The current unix timestamp"""
         if self.status == WL_CONNECTED:
             resp = self._send_command_get_response(_GET_TIME)
+            if struct.unpack('<i', resp[0]) == (0,):
+                raise ValueError("_GET_TIME returned 0")
             return struct.unpack('<i', resp[0])
         if self.status in (WL_AP_LISTENING, WL_AP_CONNECTED):
             raise RuntimeError("Cannot obtain NTP while in AP mode, must be connected to internet")


### PR DESCRIPTION
fixes #72 
on startup, sometimes it takes awhile (up to 15 seconds) for get_time() to return a non-zero result.
Raising the ValueError lets the user retry if desired


tested on PyPortal and Metro_m4_express with  with  Nina v 1.3.0 
test code:
```
import time
import board
import busio
from digitalio import DigitalInOut
from adafruit_esp32spi import adafruit_esp32spi

# If you are using a board with pre-defined ESP32 Pins:
esp32_cs = DigitalInOut(board.ESP_CS)
esp32_ready = DigitalInOut(board.ESP_BUSY)
esp32_reset = DigitalInOut(board.ESP_RESET)


spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)

print("Connecting to AP...")
while not esp.is_connected:
    try:
        esp.connect_AP(b"MYSSID", b"MYPASSWORD")
    except RuntimeError as e:
        print("could not connect to AP, retrying: ", e)
        continue

while True:
    try:
        print(esp.get_time())
    except ValueError as e:
        print(e," try again")
        pass
    time.sleep(1)
```