### PR TITLE
Add UDP support

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -721,7 +721,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             # UDP needs to finalize with this command, does the actual sending
             resp = self._send_command_get_response(_SEND_UDP_DATA_CMD, self._socknum_ll)
             if resp[0][0] != 1:
-                raise RuntimeError("Failed to send data")
+                raise RuntimeError("Failed to send UDP data")
             return
 
         if sent != len(buffer):

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -699,7 +699,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         sent = 0
         totalChunks = (len(buffer) // 64) + 1
         send_command = _SEND_DATA_TCP_CMD
-        if conn_mode == UDP_MODE: # UDP requires a different command to write
+        if conn_mode == UDP_MODE:  # UDP requires a different command to write
             send_command = _INSERT_DATABUF_TCP_CMD
         for chunk in range(totalChunks):
             resp = self._send_command_get_response(

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -722,15 +722,16 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             resp = self._send_command_get_response(_SEND_UDP_DATA_CMD, self._socknum_ll)
             if resp[0][0] != 1:
                 raise RuntimeError("Failed to send data")
-        else:
-            if sent != len(buffer):
-                raise RuntimeError(
-                    "Failed to send %d bytes (sent %d)" % (len(buffer), sent)
-                )
+            return
 
-            resp = self._send_command_get_response(_DATA_SENT_TCP_CMD, self._socknum_ll)
-            if resp[0][0] != 1:
-                raise RuntimeError("Failed to verify data sent")
+        if sent != len(buffer):
+            raise RuntimeError(
+                "Failed to send %d bytes (sent %d)" % (len(buffer), sent)
+            )
+
+        resp = self._send_command_get_response(_DATA_SENT_TCP_CMD, self._socknum_ll)
+        if resp[0][0] != 1:
+            raise RuntimeError("Failed to verify data sent")
 
     def socket_available(self, socket_num):
         """Determine how many bytes are waiting to be read on the socket"""

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -697,11 +697,11 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             print("Writing:", buffer)
         self._socknum_ll[0][0] = socket_num
         sent = 0
-        totalChunks = (len(buffer) // 64) + 1
+        total_chunks = (len(buffer) // 64) + 1
         send_command = _SEND_DATA_TCP_CMD
-        if conn_mode == UDP_MODE:  # UDP requires a different command to write
+        if conn_mode == self.UDP_MODE:  # UDP requires a different command to write
             send_command = _INSERT_DATABUF_TCP_CMD
-        for chunk in range(totalChunks):
+        for chunk in range(total_chunks):
             resp = self._send_command_get_response(
                 send_command,
                 (
@@ -712,11 +712,11 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             )
             sent += resp[0][0]
 
-        if conn_mode == UDP_MODE:
+        if conn_mode == self.UDP_MODE:
             # UDP verifies chunks on write, not bytes
-            if sent != totalChunks:
+            if sent != total_chunks:
                 raise RuntimeError(
-                    "Failed to write %d chunks (sent %d)" % (totalChunks, sent)
+                    "Failed to write %d chunks (sent %d)" % (total_chunks, sent)
                 )
             # UDP needs to finalize with this command, does the actual sending
             resp = self._send_command_get_response(_SEND_UDP_DATA_CMD, self._socknum_ll)
@@ -766,10 +766,11 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             print("*** Socket connect mode", conn_mode)
 
         self.socket_open(socket_num, dest, port, conn_mode=conn_mode)
-        if conn_mode == UDP_MODE:
+        if conn_mode == self.UDP_MODE:
             # UDP doesn't actually establish a connection
             # but the socket for writing is created via start_server
             self.start_server(port, socket_num, conn_mode)
+            return True
         else:
             times = time.monotonic()
             while (time.monotonic() - times) < 3:  # wait 3 seconds

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -771,13 +771,13 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             # but the socket for writing is created via start_server
             self.start_server(port, socket_num, conn_mode)
             return True
-        else:
-            times = time.monotonic()
-            while (time.monotonic() - times) < 3:  # wait 3 seconds
-                if self.socket_connected(socket_num):
-                    return True
-                time.sleep(0.01)
-            raise RuntimeError("Failed to establish connection")
+
+        times = time.monotonic()
+        while (time.monotonic() - times) < 3:  # wait 3 seconds
+            if self.socket_connected(socket_num):
+                return True
+            time.sleep(0.01)
+        raise RuntimeError("Failed to establish connection")
 
     def socket_close(self, socket_num):
         """Close a socket using the ESP32's internal reference number"""


### PR DESCRIPTION
Writing to UDP requires separate APIs to use to append data and finalize.

TCP sends and confirms per-write and finalize is a no-op.  UDP appends to a buffer and finalize sends all at once.

The simple socket_open method doesn't actually create a socket per https://github.com/arduino/nina-fw.

Since socket_connect is a convenience method anyway, and connect doesn't really make sense for UDP, add the start_server call for UDP to that method to have a socket to write as well as read on.

e.x. usage

esp.socket_connect(socket_num, dest, port, esp.UDP_MODE)
esp.socket_write(socket_num, buffer, esp.UDP_MODE)
avail = esp.socket_available(socket_num)
recv = esp.socket_read(socket_num, avail)
esp.socket_close(socket_num)