### PR TITLE
Wifi low power

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -451,7 +451,8 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
 
     def wifi_set_power_mode(self, power_mode):
         """Sets wi-fi power save mode on or off"""
-        resp = self._send_command_get_response(_SET_POWER_MODE_CMD, ((bool(power_mode),),))
+        resp = self._send_command_get_response(_SET_POWER_MODE_CMD,
+                                               ((bool(power_mode),),))
         if resp[0][0] != 1:
             raise RuntimeError("Failed to set power mode")
 

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -451,8 +451,9 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
 
     def wifi_set_power_mode(self, power_mode):
         """Sets wi-fi power save mode on or off"""
-        resp = self._send_command_get_response(_SET_POWER_MODE_CMD,
-                                               ((bool(power_mode),),))
+        resp = self._send_command_get_response(
+            _SET_POWER_MODE_CMD, ((bool(power_mode),),)
+        )
         if resp[0][0] != 1:
             raise RuntimeError("Failed to set power mode")
 

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -37,6 +37,7 @@ __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI.git"
 # pylint: disable=bad-whitespace
 _SET_NET_CMD = const(0x10)
 _SET_PASSPHRASE_CMD = const(0x11)
+_SET_POWER_MODE_CMD = const(0x17)
 _SET_AP_NET_CMD = const(0x18)
 _SET_AP_PASSPHRASE_CMD = const(0x19)
 _SET_DEBUG_CMD = const(0x1A)
@@ -447,6 +448,12 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         resp = self._send_command_get_response(_SET_AP_NET_CMD, [ssid, channel])
         if resp[0][0] != 1:
             raise RuntimeError("Failed to setup AP network")
+
+    def wifi_set_power_mode(self, power_mode):
+        """Sets wi-fi power save mode on or off"""
+        resp = self._send_command_get_response(_SET_POWER_MODE_CMD, ((bool(power_mode),),))
+        if resp[0][0] != 1:
+            raise RuntimeError("Failed to set power mode")
 
     def _wifi_set_ap_passphrase(self, ssid, passphrase, channel):
         """Creates an Access point with SSID, passphrase, and Channel"""


### PR DESCRIPTION
Expose the NINA firmware `setPowerMode` function. Note that:

> Modem-sleep mode works in Station-only mode and the station must connect to the AP first.

NINA firmware currently implements only `WiFi.lowPowerMode()` or `WiFi.noLowPowerMode()`, and low power mode defaults to `WIFI_PS_MIN_MODEM`: 

> Minimum modem power saving. In this mode, station wakes up to receive beacon every DTIM period

Preliminary testing of low power mode vs. no low power mode indicates potentially significant difference in power usage, but it is dependent on AP settings and wi-fi usage within the client CircuitPython application.

However, though I may be misunderstanding something, it appears that the default NINA build enables `WIFI_PS_MIN_MODEM` (though I don't pretend to understand the build process and can't find where it's done in the code). Crude testing with this PR code shows similar battery life for code with no call to `esp.wifi_set_power_mode()` and call to `esp.wifi_set_power_mode(True)`. Call to `esp.wifi_set_power_mode(False)` does increase power usage, but there may be a benefit in some cases:

> provides minimum latency for receiving Wi-Fi data in real time

Background information is here:
[https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#esp32-wi-fi-power-saving-mode](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/api-guides/wifi.html#esp32-wi-fi-power-saving-mode)

A future enhancement for lower power usage, which would require a change to NINA, could add the option for the higher power saving mode by using `esp_wifi_set_ps()` with the `WIFI_PS_MAX_MODEM` value (caveats in the link above), instead of the current call to`WiFi.lowPowerMode()`.

There are other low-power features of the ESP32, but they would require development from scratch in the NINA firmware, plus exposure in this library. There's always the `EN` pin for super low power usage ;-)