### PR TITLE
remove bad-whitespace pylint directive

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -51,7 +51,6 @@ from adafruit_bus_device.spi_device import SPIDevice
 __version__ = "0.0.0-auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI.git"
 
-# pylint: disable=bad-whitespace
 _SET_NET_CMD = const(0x10)
 _SET_PASSPHRASE_CMD = const(0x11)
 _SET_AP_NET_CMD = const(0x18)
@@ -140,7 +139,6 @@ ADC_ATTEN_DB_0 = const(0)
 ADC_ATTEN_DB_2_5 = const(1)
 ADC_ATTEN_DB_6 = const(2)
 ADC_ATTEN_DB_11 = const(3)
-# pylint: enable=bad-whitespace
 
 
 class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-instance-attributes

--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -15,9 +15,9 @@ WiFi Manager for making ESP32 SPI as WiFi much easier
 
 from time import sleep
 from micropython import const
+import adafruit_requests as requests
 from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
-import adafruit_requests as requests
 
 
 class ESPSPI_WiFiManager:

--- a/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
@@ -31,8 +31,8 @@ https://www.python.org/dev/peps/pep-0333/
 import io
 import gc
 from micropython import const
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_requests import parse_headers
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
 _the_interface = None  # pylint: disable=invalid-name
 

--- a/examples/esp32spi_cheerlights.py
+++ b/examples/esp32spi_cheerlights.py
@@ -6,11 +6,11 @@ import board
 import busio
 from digitalio import DigitalInOut
 
-from adafruit_esp32spi import adafruit_esp32spi
-from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-
 import neopixel
 import adafruit_fancyled.adafruit_fancyled as fancy
+
+from adafruit_esp32spi import adafruit_esp32spi
+from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 
 # Get wifi details and more from a secrets.py file
 try:

--- a/examples/esp32spi_localtime.py
+++ b/examples/esp32spi_localtime.py
@@ -6,9 +6,9 @@ import board
 import busio
 from digitalio import DigitalInOut
 import neopixel
+import rtc
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
-import rtc
 
 # Get wifi details and more from a secrets.py file
 try:

--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -4,9 +4,9 @@
 import board
 import busio
 from digitalio import DigitalInOut
+import adafruit_requests as requests
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_esp32spi import adafruit_esp32spi
-import adafruit_requests as requests
 
 # Get wifi details and more from a secrets.py file
 try:

--- a/examples/esp32spi_wpa2ent_simpletest.py
+++ b/examples/esp32spi_wpa2ent_simpletest.py
@@ -15,9 +15,9 @@ import board
 import busio
 from digitalio import DigitalInOut
 
+import adafruit_requests as requests
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_esp32spi import adafruit_esp32spi
-import adafruit_requests as requests
 
 # Version number comparison code. Credit to gnud on stackoverflow
 # (https://stackoverflow.com/a/1714190), swapping out cmp() to

--- a/examples/server/esp32spi_wsgiserver.py
+++ b/examples/server/esp32spi_wsgiserver.py
@@ -216,7 +216,7 @@ except (OSError) as e:
         Please create one named {0} in the root of the device filesystem.""".format(
             static
         )
-    )
+    ) from e
 
 web_app = SimpleWSGIApplication(static_dir=static)
 web_app.on("GET", "/led_on", led_on)


### PR DESCRIPTION
This directive has been removed from pylint 2.6.0.