### PR TITLE
wsgiserver: implement parse_headers

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
@@ -52,7 +52,7 @@ def parse_headers(client):
         line = str(client.readline(), "utf-8")
         if not line:
             break
-        title, content = line.split(':', 1)
+        title, content = line.split(":", 1)
         headers[title.strip().lower()] = content.strip()
     return headers
 
@@ -170,7 +170,10 @@ class WSGIServer:
             ex ("header-name", "header value")
         """
         self._response_status = status
-        self._response_headers = [("Server", "esp32WSGIServer"), ("Connection", "close")] + response_headers
+        self._response_headers = [
+            ("Server", "esp32WSGIServer"),
+            ("Connection", "close"),
+        ] + response_headers
 
     def _get_environ(self, client):
         """

--- a/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
@@ -47,6 +47,10 @@ NO_SOCK_AVAIL = const(255)
 
 
 def parse_headers(client):
+    """
+    Parses the header portion of an HTTP request from the socket.
+    Expects first line of HTTP request to have been read already.
+    """
     headers = {}
     while True:
         line = str(client.readline(), "utf-8")


### PR DESCRIPTION
This PR implements parse_headers, which is not available in adafruit_requests anymore.

It also adds a default return status of 500 Internal Server Error, this helped me when debugging an app using Adafruit_CircuitPython_WSGI.

Lastly, we always add a Connection: close header. The server is not ready to handle keep-alive requests, it seems better to make it clear for the client.
