### PR TITLE
Expose NINA disconnect

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -505,6 +505,12 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             self.reset()
             return False
 
+    def disconnect(self):
+        """Disconnect from the access point"""
+        resp = self._send_command_get_response(_DISCONNECT_CMD)
+        if resp[0][0] != 1:
+            raise RuntimeError("Failed to disconnect")
+
     def connect(self, secrets):
         """Connect to an access point using a secrets dictionary
         that contains a 'ssid' and 'password' entry"""


### PR DESCRIPTION
Expose the existing `disconnect` [function](https://github.com/adafruit/nina-fw/blob/f2a0e601b23212dda4fe305eab30af49a7c7fb41/main/CommandHandler.cpp#L680) in NINA, so that a CircuitPython client can explicitly disconnect from the connected AP.

There are a variety of use cases for this, including saving power when Wi-Fi is not needed (see [https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/issues/63](https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/issues/63) and [https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/pull/101](https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/pull/101)).