### PR TITLE
Create esp32spi_tcp_client.py

### DIFF
--- a/examples/esp32spi_tcp_client.py
+++ b/examples/esp32spi_tcp_client.py
@@ -37,7 +37,7 @@ print("Connecting")
 s.connect(socketaddr)
 
 print("Sending")
-s.send(b'Hello, world')
+s.send(b"Hello, world")
 
 print("Receiving")
 print(s.recv(128))

--- a/examples/esp32spi_tcp_client.py
+++ b/examples/esp32spi_tcp_client.py
@@ -1,0 +1,43 @@
+# SPDX-FileCopyrightText: 2021 Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+import board
+from digitalio import DigitalInOut
+from adafruit_esp32spi import adafruit_esp32spi
+import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_requests as requests
+from secrets import secrets
+
+
+TIMEOUT = 5
+# adjust host and port to match server
+HOST = "192.168.10.179"
+PORT = 5000
+
+# PyPortal or similar; adjust pins as needed
+spi = board.SPI()
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
+esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
+
+# connect to wifi AP
+esp.connect(secrets)
+
+# test for connectivity to server
+print("Server ping:", esp.ping(HOST), "ms")
+
+# create the socket
+socket.set_interface(esp)
+socketaddr = socket.getaddrinfo(HOST, PORT)[0][4]
+s = socket.socket()
+s.settimeout(TIMEOUT)
+
+print("Connecting")
+s.connect(socketaddr)
+
+print("Sending")
+s.send(b'Hello, world')
+
+print("Receiving")
+print(s.recv(128))

--- a/examples/esp32spi_tcp_client.py
+++ b/examples/esp32spi_tcp_client.py
@@ -10,11 +10,11 @@ from secrets import secrets
 
 
 TIMEOUT = 5
-# adjust host and port to match server
-HOST = "192.168.10.179"
-PORT = 5000
+# edit host and port to match server
+HOST = "wifitest.adafruit.com"
+PORT = 80
 
-# PyPortal or similar; adjust pins as needed
+# PyPortal or similar; edit pins as needed
 spi = board.SPI()
 esp32_cs = DigitalInOut(board.ESP_CS)
 esp32_ready = DigitalInOut(board.ESP_BUSY)
@@ -37,7 +37,7 @@ print("Connecting")
 s.connect(socketaddr)
 
 print("Sending")
-s.send(b"Hello, world")
+s.send(b"HEAD / HTTP/1.0\r\n\r\n")
 
 print("Receiving")
-print(s.recv(128))
+print(s.recv(1024))


### PR DESCRIPTION
A simple TCP client example using ESP32SPI.

Requires running a TCP server listening on the same port. For example, CPython on a general-purpose computer:
https://github.com/adafruit/circuitpython/blob/main/tests/circuitpython-manual/socketpool/client/host-server.py
or CircuitPython native sockets:
https://github.com/adafruit/circuitpython/blob/main/tests/circuitpython-manual/socketpool/server/cpy-server.py