### PR TITLE
change timeout to retry count in _wait_spi_char

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -260,9 +260,8 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             print("\t\tRead:", [hex(i) for i in buffer])
 
     def _wait_spi_char(self, spi, desired):
-        """Read a byte with a time-out, and if we get it, check that its what we expect"""
-        times = time.monotonic()
-        while (time.monotonic() - times) < 0.1:
+        """Read a byte with a retry loop, and if we get it, check that its what we expect"""
+        for _ in range(50):
             r = self._read_byte(spi)
             if r == _ERR_CMD:
                 raise RuntimeError("Error response to command")

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -261,12 +261,13 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
 
     def _wait_spi_char(self, spi, desired):
         """Read a byte with a retry loop, and if we get it, check that its what we expect"""
-        for _ in range(50):
+        for _ in range(10):
             r = self._read_byte(spi)
             if r == _ERR_CMD:
                 raise RuntimeError("Error response to command")
             if r == desired:
                 return True
+            time.sleep(0.01)
         raise RuntimeError("Timed out waiting for SPI char")
 
     def _check_data(self, spi, desired):


### PR DESCRIPTION
This change modifies the adafruit_esp32spi.py's _wait_spi_char function to use a retry count rather than a 100 millisecond timeout.  Since 100 milliseconds is less that a typical garbage collect, the timeout causes spurious timeout exceptions to be reported.  The retry count is set to 50, which is about the number of times the existing code will go around its timeout loop in 100 milliseconds.

See the attached file for more details

[conclusions.txt](https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI/files/6268121/conclusions.txt)
