### PR TITLE
Change _pin arguments to _dio

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -134,7 +134,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
 
     # pylint: disable=too-many-arguments
     def __init__(
-        self, spi, cs_pin, ready_pin, reset_pin, gpio0_pin=None, *, debug=False
+        self, spi, cs_dio, ready_dio, reset_dio, gpio0_dio=None, *, debug=False
     ):
         self._debug = debug
         self.set_psk = False
@@ -145,10 +145,10 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         self._socknum_ll = [[0]]  # pre-made list of list of socket #
 
         self._spi_device = SPIDevice(spi, cs_pin, baudrate=8000000)
-        self._cs = cs_pin
-        self._ready = ready_pin
-        self._reset = reset_pin
-        self._gpio0 = gpio0_pin
+        self._cs = cs_dio
+        self._ready = ready_dio
+        self._reset = reset_dio
+        self._gpio0 = gpio0_dio
         self._cs.direction = Direction.OUTPUT
         self._ready.direction = Direction.INPUT
         self._reset.direction = Direction.OUTPUT

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -144,7 +144,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         self._sendbuf = bytearray(256)  # buffer for command sending
         self._socknum_ll = [[0]]  # pre-made list of list of socket #
 
-        self._spi_device = SPIDevice(spi, cs_pin, baudrate=8000000)
+        self._spi_device = SPIDevice(spi, cs_dio, baudrate=8000000)
         self._cs = cs_dio
         self._ready = ready_dio
         self._reset = reset_dio


### PR DESCRIPTION
Addresses Issue #121 by changing relevant argument names from `*_pin` to `*_dio`.  I chose this instead of just using `*` argument names so it would be explicitly clear it should be a `DigitalInOut` instance passed as the argument, and also because I know there is a `reset` parameter so that argument wouldn't be confused for a boolean argument or something like that.