### PR TITLE
Add missing files to API reference

### DIFF
--- a/adafruit_esp32spi/digitalio.py
+++ b/adafruit_esp32spi/digitalio.py
@@ -8,7 +8,7 @@
 DigitalIO for ESP32 over SPI.
 
 * Author(s): Brent Rubell, based on Adafruit_Blinka digitalio implementation
-and bcm283x Pin implementation.
+    and bcm283x Pin implementation.
 
 https://github.com/adafruit/Adafruit_Blinka/blob/master/src/adafruit_blinka/microcontroller/bcm283x/pin.py
 https://github.com/adafruit/Adafruit_Blinka/blob/master/src/digitalio.py

--- a/adafruit_esp32spi/digitalio.py
+++ b/adafruit_esp32spi/digitalio.py
@@ -195,7 +195,7 @@ class DigitalInOut:
     def drive_mode(self, mode):
         """Sets the pin drive mode.
         :param DriveMode mode: Defines the drive mode when outputting digital values.
-        Either PUSH_PULL or OPEN_DRAIN
+            Either PUSH_PULL or OPEN_DRAIN
         """
         if mode is DriveMode.OPEN_DRAIN:
             raise NotImplementedError(

--- a/adafruit_esp32spi/digitalio.py
+++ b/adafruit_esp32spi/digitalio.py
@@ -9,6 +9,7 @@ DigitalIO for ESP32 over SPI.
 
 * Author(s): Brent Rubell, based on Adafruit_Blinka digitalio implementation
 and bcm283x Pin implementation.
+
 https://github.com/adafruit/Adafruit_Blinka/blob/master/src/adafruit_blinka/microcontroller/bcm283x/pin.py
 https://github.com/adafruit/Adafruit_Blinka/blob/master/src/digitalio.py
 """

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -9,3 +9,15 @@
 
 .. automodule:: adafruit_esp32spi.adafruit_esp32spi_socket
    :members:
+
+.. automodule:: adafruit_esp32spi.adafruit_esp32spi_wifimanager
+   :members:
+
+.. automodule:: adafruit_esp32spi.adafruit_esp32spi_wsgiserver
+   :members:
+
+.. automodule:: adafruit_esp32spi.digitalio
+   :members:
+
+.. automodule:: adafruit_esp32spi.PWMOut
+   :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -25,7 +25,7 @@ extensions = [
 # Uncomment the below if you use native CircuitPython modules such as
 # digitalio, micropython and busio. List the modules you use. Without it, the
 # autodoc module docs will fail to generate with a warning.
-# autodoc_mock_imports = ["digitalio", "busio"]
+autodoc_mock_imports = ["adafruit_requests"]
 
 
 intersphinx_mapping = {


### PR DESCRIPTION
Adds files not currently viewable in ReadTheDocs by adding them to `api.rst`

Also helps with Issue #138 by making the annotations there actually viewable in RTD.