### PR TITLE
Allow optional nbytes parameter for recv_into

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -184,7 +184,7 @@ class socket:
             if avail:
                 stamp = time.monotonic()
                 recv = _the_interface.socket_read(self._socknum, min(to_read, avail))
-                # received.append(recv)
+                received.append(recv)
                 start = len(buffer) - to_read
                 to_read -= len(recv)
                 end = len(buffer) - to_read

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -161,14 +161,14 @@ class socket:
         gc.collect()
         return ret
 
-    def recv_into(self, buffer):
+    def recv_into(self, buffer, nbytes=None):
         """Read some bytes from the connected remote address into a given buffer
 
         :param bytearray buffer: The buffer to read into
         """
 
         stamp = time.monotonic()
-        to_read = len(buffer)
+        to_read = len(buffer) if nbytes is None else nbytes
         received = []
         while to_read > 0:
             # print("Bytes to read:", to_read)

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -172,7 +172,7 @@ class socket:
 
         stamp = time.monotonic()
         to_read = len(buffer)
-        limit = to_read if nbytes is None else to_read - nbytes
+        limit = 0 if nbytes is None else to_read - nbytes
         received = []
         while to_read > limit:
             # print("Bytes to read:", to_read)

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -165,12 +165,16 @@ class socket:
         """Read some bytes from the connected remote address into a given buffer
 
         :param bytearray buffer: The buffer to read into
+        :param int nbytes: (Optional) Number of bytes to receive
+            default is as many as possible before filling the
+            buffer or timing out
         """
 
         stamp = time.monotonic()
-        to_read = len(buffer) if nbytes is None else nbytes
+        to_read = len(buffer)
+        nbytes = to_read if nbytes is None else to_read - nbytes
         received = []
-        while to_read > 0:
+        while to_read > len(buffer) - nbytes:
             # print("Bytes to read:", to_read)
             avail = self.available()
             if avail:

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -177,8 +177,9 @@ class socket:
 
         stamp = time.monotonic()
         to_read = len(buffer)
+        limit = 0 if nbytes == 0 else to_read - nbytes
         received = []
-        while to_read > nbytes:
+        while to_read > limit:
             # print("Bytes to read:", to_read)
             avail = self.available()
             if avail:

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -161,20 +161,24 @@ class socket:
         gc.collect()
         return ret
 
-    def recv_into(self, buffer, nbytes=None):
+    def recv_into(self, buffer, nbytes=0):
         """Read some bytes from the connected remote address into a given buffer
 
         :param bytearray buffer: The buffer to read into
-        :param int nbytes: (Optional) Number of bytes to receive
-            default is as many as possible before filling the
+        :param int nbytes: (Optional) Number of bytes to receive default is 0,
+            which will receive as many bytes as possible before filling the
             buffer or timing out
         """
 
+        if not (0 <= nbytes <= len(buffer)):
+            raise ValueError(
+                "Can only read number of bytes between 0 and length of supplied buffer"
+            )
+
         stamp = time.monotonic()
         to_read = len(buffer)
-        limit = 0 if nbytes is None else to_read - nbytes
         received = []
-        while to_read > limit:
+        while to_read > nbytes:
             # print("Bytes to read:", to_read)
             avail = self.available()
             if avail:

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -170,7 +170,7 @@ class socket:
             buffer or timing out
         """
 
-        if not (0 <= nbytes <= len(buffer)):
+        if not 0 <= nbytes <= len(buffer):
             raise ValueError(
                 "Can only read number of bytes between 0 and length of supplied buffer"
             )

--- a/adafruit_esp32spi/adafruit_esp32spi_socket.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socket.py
@@ -172,9 +172,9 @@ class socket:
 
         stamp = time.monotonic()
         to_read = len(buffer)
-        nbytes = to_read if nbytes is None else to_read - nbytes
+        limit = to_read if nbytes is None else to_read - nbytes
         received = []
-        while to_read > len(buffer) - nbytes:
+        while to_read > limit:
             # print("Bytes to read:", to_read)
             avail = self.available()
             if avail:


### PR DESCRIPTION
That sweet, sweet hotfix for Issue #154!  Sorry for breaking some things, and thanks to @FoamyGuy to summarizing.  Default argument is None which still triggers filling buffer as much as possible, length should override that now.