### PR TITLE
Add adafruit_requests to requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@
 
 Adafruit-Blinka
 adafruit-circuitpython-busdevice
+adafruit-circuitpython-requests


### PR DESCRIPTION
`adafruit_esp32spi_wifimanager.py` uses `adafruit_requests`.