### PR TITLE
Close #174 by sending entire webserver response to ESP32 in one go if possible

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
@@ -119,11 +119,11 @@ class WSGIServer:
                 response += "{0}: {1}\r\n".format(*header)
             response += "\r\n"
             self._client_sock.send(response.encode("utf-8"))
-            if isinstance(result, bytes): # send whole response if possible (see #174)
+            if isinstance(result, bytes):  # send whole response if possible (see #174)
                 self._client_sock.send(result)
             elif isinstance(result, str):
                 self._client_sock.send(result.encode("utf-8"))
-            else: # fall back to sending byte-by-byte
+            else:  # fall back to sending byte-by-byte
                 for data in result:
                     if isinstance(data, bytes):
                         self._client_sock.send(data)

--- a/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wsgiserver.py
@@ -119,11 +119,16 @@ class WSGIServer:
                 response += "{0}: {1}\r\n".format(*header)
             response += "\r\n"
             self._client_sock.send(response.encode("utf-8"))
-            for data in result:
-                if isinstance(data, bytes):
-                    self._client_sock.send(data)
-                else:
-                    self._client_sock.send(data.encode("utf-8"))
+            if isinstance(result, bytes): # send whole response if possible (see #174)
+                self._client_sock.send(result)
+            elif isinstance(result, str):
+                self._client_sock.send(result.encode("utf-8"))
+            else: # fall back to sending byte-by-byte
+                for data in result:
+                    if isinstance(data, bytes):
+                        self._client_sock.send(data)
+                    else:
+                        self._client_sock.send(data.encode("utf-8"))
             gc.collect()
         finally:
             if self._debug > 2:


### PR DESCRIPTION
This fixes #174, and gets my connection speed on a Metro M4 Airlift Lite from about 800 bps to something like 178 kpbs when serving a webpage, though your mileage may vary. For some reason `finish_response` would be called an empty array after the initial call with the intended response string, so I've left the original handling logic behind some type checks if that array ends up being non-empty. It's very possible I've misunderstood how WSGI is working here and more needs to be done with this, but it seems to handle what I've thrown at it.