### PR TITLE
Use setting.toml instead of secrets.py

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -27,10 +27,12 @@ Implementation Notes
 """
 
 import struct
+import os
 import time
 from micropython import const
 from adafruit_bus_device.spi_device import SPIDevice
 from digitalio import Direction
+
 
 __version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/adafruit/Adafruit_CircuitPython_ESP32SPI.git"
@@ -568,10 +570,10 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         if resp[0][0] != 1:
             raise OSError("Failed to disconnect")
 
-    def connect(self, secrets):
+    def connect(self):
         """Connect to an access point using a secrets dictionary
         that contains a 'ssid' and 'password' entry"""
-        self.connect_AP(secrets["ssid"], secrets["password"])
+        self.connect_AP(os.getenv("ssid"), os.getenv("password"))
 
     def connect_AP(self, ssid, password, timeout_s=10):  # pylint: disable=invalid-name
         """Connect to an access point with given name and password.
@@ -586,6 +588,12 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             print(
                 f"Connect to AP: {ssid=}, password=\
                     {repr(password if self._debug_show_secrets else '*' * len(password))}"
+            )
+
+        if ssid is None or password is None:
+            raise RuntimeError(
+                "Must provide ssid and password in settings.toml."
+                "Please add them there and try again."
             )
         if isinstance(ssid, str):
             ssid = bytes(ssid, "utf-8")

--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -12,7 +12,7 @@ WiFi Manager for making ESP32 SPI as WiFi much easier
 """
 
 # pylint: disable=no-name-in-module
-
+import os
 from time import sleep
 from micropython import const
 import adafruit_requests as requests
@@ -33,7 +33,6 @@ class ESPSPI_WiFiManager:
     def __init__(
         self,
         esp,
-        secrets,
         status_pixel=None,
         attempts=2,
         connection_type=NORMAL,
@@ -41,7 +40,6 @@ class ESPSPI_WiFiManager:
     ):
         """
         :param ESP_SPIcontrol esp: The ESP object we are using
-        :param dict secrets: The WiFi and Adafruit IO secrets dict (See examples)
         :param status_pixel: (Optional) The pixel device - A NeoPixel, DotStar,
             or RGB LED (default=None). The status LED, if given, turns red when
             attempting to connect to a Wi-Fi network or create an access point,
@@ -55,8 +53,8 @@ class ESPSPI_WiFiManager:
         # Read the settings
         self.esp = esp
         self.debug = debug
-        self.ssid = secrets["ssid"]
-        self.password = secrets.get("password", None)
+        self.ssid = os.getenv("ssid")
+        self.password = os.getenv("password")
         self.attempts = attempts
         self._connection_type = connection_type
         requests.set_socket(socket, esp)
@@ -65,18 +63,18 @@ class ESPSPI_WiFiManager:
         self._ap_index = 0
 
         # Check for WPA2 Enterprise keys in the secrets dictionary and load them if they exist
-        if secrets.get("ent_ssid"):
-            self.ent_ssid = secrets["ent_ssid"]
+        if os.getenv("ent_ssid") is not None:
+            self.ent_ssid = os.getenv("ent_ssid")
         else:
-            self.ent_ssid = secrets["ssid"]
-        if secrets.get("ent_ident"):
-            self.ent_ident = secrets["ent_ident"]
+            self.ent_ssid = os.getenv("ssid")
+        if os.getenv("ent_ident") is not None:
+            self.ent_ident = os.getenv("ent_ident")
         else:
             self.ent_ident = ""
-        if secrets.get("ent_user"):
-            self.ent_user = secrets["ent_user"]
-        if secrets.get("ent_password"):
-            self.ent_password = secrets["ent_password"]
+        if os.getenv("ent_user") is not None:
+            self.ent_user = os.getenv("ent_user")
+        if os.getenv("ent_password") is not None:
+            self.ent_password = os.getenv("ent_password")
 
     # pylint: enable=too-many-arguments
 

--- a/examples/esp32spi_cheerlights.py
+++ b/examples/esp32spi_cheerlights.py
@@ -12,21 +12,23 @@ import adafruit_fancyled.adafruit_fancyled as fancy
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Set wifi details and more from a settings.toml file
 
 print("ESP32 SPI webclient test")
 
 DATA_SOURCE = "https://api.thingspeak.com/channels/1417/feeds.json?results=1"
 DATA_LOCATION = ["feeds", 0, "field2"]
 
-esp32_cs = DigitalInOut(board.D9)
-esp32_ready = DigitalInOut(board.D10)
-esp32_reset = DigitalInOut(board.D5)
+# If you are using a board with pre-defined ESP32 Pins:
+esp32_cs = DigitalInOut(board.ESP_CS)
+esp32_ready = DigitalInOut(board.ESP_BUSY)
+esp32_reset = DigitalInOut(board.ESP_RESET)
+
+# If you have an externally connected ESP32:
+# esp32_cs = DigitalInOut(board.D9)
+# esp32_ready = DigitalInOut(board.D10)
+# esp32_reset = DigitalInOut(board.D5)
+
 spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 """Use below for Most Boards"""
@@ -35,7 +37,7 @@ status_light = neopixel.NeoPixel(
 )  # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 # status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, status_light)
 
 # neopixels
 pixels = neopixel.NeoPixel(board.A1, 16, brightness=0.3)

--- a/examples/esp32spi_ipconfig.py
+++ b/examples/esp32spi_ipconfig.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2019 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import time
 import board
 import busio
@@ -8,12 +9,12 @@ from digitalio import DigitalInOut
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_esp32spi import adafruit_esp32spi
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Set wifi details and more from a settings.toml file
+if os.getenv("ssid") is None or os.getenv("password") is None:
+    raise RuntimeError(
+        "Must provide 'ssid', 'password' in settings.toml. "
+        "Please add them there and try again."
+    )
 
 HOSTNAME = "esp32-spi-hostname-test"
 
@@ -48,7 +49,7 @@ print("MAC addr:", [hex(i) for i in esp.MAC_address])
 print("Connecting to AP...")
 while not esp.is_connected:
     try:
-        esp.connect_AP(secrets["ssid"], secrets["password"])
+        esp.connect_AP(os.getenv("ssid"), os.getenv("password"))
     except OSError as e:
         print("could not connect to AP, retrying: ", e)
         continue

--- a/examples/esp32spi_localtime.py
+++ b/examples/esp32spi_localtime.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2019 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import time
 import board
 import busio
@@ -10,12 +11,12 @@ import rtc
 from adafruit_esp32spi import adafruit_esp32spi
 from adafruit_esp32spi import adafruit_esp32spi_wifimanager
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Set wifi details and more from a settings.toml file
+if os.getenv("ssid") is None or os.getenv("password") is None:
+    raise RuntimeError(
+        "Must provide 'ssid', 'password' in settings.toml. "
+        "Please add them there and try again."
+    )
 
 print("ESP32 local time")
 
@@ -32,7 +33,7 @@ status_light = neopixel.NeoPixel(
 )  # Uncomment for Most Boards
 """Uncomment below for ItsyBitsy M4"""
 # status_light = dotstar.DotStar(board.APA102_SCK, board.APA102_MOSI, 1, brightness=0.2)
-wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, secrets, status_light)
+wifi = adafruit_esp32spi_wifimanager.ESPSPI_WiFiManager(esp, status_light)
 
 the_rtc = rtc.RTC()
 

--- a/examples/esp32spi_secrets.py
+++ b/examples/esp32spi_secrets.py
@@ -1,6 +1,9 @@
 # SPDX-FileCopyrightText: 2019 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+# THIS FILE IS DEPRECATED.
+# Use settings.toml instead.
+
 # This file is where you keep secret settings, passwords, and tokens!
 # If you put them in the code you risk committing that info or sharing it
 

--- a/examples/esp32spi_settings.toml
+++ b/examples/esp32spi_settings.toml
@@ -1,0 +1,14 @@
+# SPDX-FileCopyrightText: 2019 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+# This file is where you keep secret settings, passwords, and tokens!
+# If you put them in the code you risk committing that info or sharing it
+
+# The file should be renamed to `settings.toml` and saved in the root of
+# the CIRCUITPY drive.
+
+ssid="yourssid"
+password="yourpassword"
+timezone="America/New_York"  # Check http://worldtimeapi.org/timezones
+aio_username="youraiousername"
+aio_key="youraiokey"

--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2019 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import board
 import busio
 from digitalio import DigitalInOut
@@ -8,12 +9,12 @@ import adafruit_requests as requests
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_esp32spi import adafruit_esp32spi
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Set wifi details and more from a settings.toml file
+if os.getenv("ssid") is None or os.getenv("password") is None:
+    raise RuntimeError(
+        "Must provide 'ssid', 'password' in settings.toml. "
+        "Please add them there and try again."
+    )
 
 print("ESP32 SPI webclient test")
 
@@ -58,7 +59,7 @@ for ap in esp.scan_networks():
 print("Connecting to AP...")
 while not esp.is_connected:
     try:
-        esp.connect_AP(secrets["ssid"], secrets["password"])
+        esp.connect_AP(os.getenv("ssid"), os.getenv("password"))
     except OSError as e:
         print("could not connect to AP, retrying: ", e)
         continue

--- a/examples/esp32spi_simpletest_rp2040.py
+++ b/examples/esp32spi_simpletest_rp2040.py
@@ -1,6 +1,7 @@
 # SPDX-FileCopyrightText: 2019 ladyada for Adafruit Industries
 # SPDX-License-Identifier: MIT
 
+import os
 import board
 import busio
 from digitalio import DigitalInOut
@@ -8,12 +9,12 @@ import adafruit_requests as requests
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 from adafruit_esp32spi import adafruit_esp32spi
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Set wifi details and more from a settings.toml file
+if os.getenv("ssid") is None or os.getenv("password") is None:
+    raise RuntimeError(
+        "Must provide 'ssid', 'password' in settings.toml. "
+        "Please add them there and try again."
+    )
 
 print("Raspberry Pi RP2040 - ESP32 SPI webclient test")
 
@@ -41,7 +42,7 @@ for ap in esp.scan_networks():
 print("Connecting to AP...")
 while not esp.is_connected:
     try:
-        esp.connect_AP(secrets["ssid"], secrets["password"])
+        esp.connect_AP(os.getenv("ssid"), os.getenv("password"))
     except OSError as e:
         print("could not connect to AP, retrying: ", e)
         continue

--- a/examples/esp32spi_tcp_client.py
+++ b/examples/esp32spi_tcp_client.py
@@ -1,7 +1,7 @@
 # SPDX-FileCopyrightText: 2021 Adafruit Industries
 # SPDX-License-Identifier: MIT
 
-from secrets import secrets  # pylint: disable=no-name-in-module
+
 import board
 from digitalio import DigitalInOut
 from adafruit_esp32spi import adafruit_esp32spi
@@ -21,7 +21,7 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
 # connect to wifi AP
-esp.connect(secrets)
+esp.connect()
 
 # test for connectivity to server
 print("Server ping:", esp.ping(HOST), "ms")

--- a/examples/esp32spi_udp_client.py
+++ b/examples/esp32spi_udp_client.py
@@ -8,12 +8,8 @@ from digitalio import DigitalInOut
 from adafruit_esp32spi import adafruit_esp32spi
 import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
-# Get wifi details and more from a secrets.py file
-try:
-    from secrets import secrets
-except ImportError:
-    print("WiFi secrets are kept in secrets.py, please add them there!")
-    raise
+# Set wifi details and more from a settings.toml file
+
 
 TIMEOUT = 5
 # edit host and port to match server
@@ -29,7 +25,7 @@ esp32_reset = DigitalInOut(board.ESP_RESET)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
 # connect to wifi AP
-esp.connect(secrets)
+esp.connect()
 
 # test for connectivity to server
 print("Server ping:", esp.ping(HOST), "ms")


### PR DESCRIPTION
@kattni These are the changes needed within this library to switch over to settings.toml. It does seem to work as expected with the examples in this repo tested on a PyPortal 8.2.0.


There are examples in other repos, and in various learn guide projects that use secrets.py as well. Many of the learn guides have this page dedicated to internet connection: https://learn.adafruit.com/pyportal-weather-station/internet-connect which also contains code an information related to secrets.py. We'd probably want to have a new revision of that page that is centered around settings.toml instead. 