### PR TITLE
Remove legacy requests.set_socket

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -15,9 +15,9 @@ WiFi Manager for making ESP32 SPI as WiFi much easier
 
 from time import sleep
 from micropython import const
-import adafruit_requests as requests
+import adafruit_connection_manager
+import adafruit_requests
 from adafruit_esp32spi import adafruit_esp32spi
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
 
 
 # pylint: disable=too-many-instance-attributes
@@ -61,10 +61,14 @@ class ESPSPI_WiFiManager:
         self.password = secrets.get("password", None)
         self.attempts = attempts
         self._connection_type = connection_type
-        requests.set_socket(socket, esp)
         self.statuspix = status_pixel
         self.pixel_status(0)
         self._ap_index = 0
+
+        # create requests session
+        pool = adafruit_connection_manager.get_radio_socketpool(self.esp)
+        ssl_context = adafruit_connection_manager.get_radio_ssl_context(self.esp)
+        self._requests = adafruit_requests.Session(pool, ssl_context)
 
         # Check for WPA2 Enterprise keys in the secrets dictionary and load them if they exist
         self.ent_ssid = secrets.get("ent_ssid", secrets["ssid"])
@@ -220,7 +224,7 @@ class ESPSPI_WiFiManager:
         if not self.esp.is_connected:
             self.connect()
         self.pixel_status((0, 0, 100))
-        return_val = requests.get(url, **kw)
+        return_val = self._requests.get(url, **kw)
         self.pixel_status(0)
         return return_val
 
@@ -239,7 +243,7 @@ class ESPSPI_WiFiManager:
         if not self.esp.is_connected:
             self.connect()
         self.pixel_status((0, 0, 100))
-        return_val = requests.post(url, **kw)
+        return_val = self._requests.post(url, **kw)
         self.pixel_status(0)
         return return_val
 
@@ -258,7 +262,7 @@ class ESPSPI_WiFiManager:
         if not self.esp.is_connected:
             self.connect()
         self.pixel_status((0, 0, 100))
-        return_val = requests.put(url, **kw)
+        return_val = self._requests.put(url, **kw)
         self.pixel_status(0)
         return return_val
 
@@ -277,7 +281,7 @@ class ESPSPI_WiFiManager:
         if not self.esp.is_connected:
             self.connect()
         self.pixel_status((0, 0, 100))
-        return_val = requests.patch(url, **kw)
+        return_val = self._requests.patch(url, **kw)
         self.pixel_status(0)
         return return_val
 
@@ -296,7 +300,7 @@ class ESPSPI_WiFiManager:
         if not self.esp.is_connected:
             self.connect()
         self.pixel_status((0, 0, 100))
-        return_val = requests.delete(url, **kw)
+        return_val = self._requests.delete(url, **kw)
         self.pixel_status(0)
         return return_val
 

--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -5,8 +5,8 @@ from os import getenv
 import board
 import busio
 from digitalio import DigitalInOut
-import adafruit_requests as requests
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+import adafruit_requests
 from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a settings.toml file
@@ -57,7 +57,9 @@ else:
     spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
-requests.set_socket(socket, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
+requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")

--- a/examples/esp32spi_simpletest_rp2040.py
+++ b/examples/esp32spi_simpletest_rp2040.py
@@ -5,8 +5,8 @@ from os import getenv
 import board
 import busio
 from digitalio import DigitalInOut
-import adafruit_requests as requests
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+import adafruit_requests
 from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a settings.toml file
@@ -36,7 +36,9 @@ esp32_reset = DigitalInOut(board.GP15)
 spi = busio.SPI(board.GP10, board.GP11, board.GP12)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
-requests.set_socket(socket, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
+requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")

--- a/examples/esp32spi_wpa2ent_simpletest.py
+++ b/examples/esp32spi_wpa2ent_simpletest.py
@@ -14,9 +14,8 @@ import time
 import board
 import busio
 from digitalio import DigitalInOut
-
-import adafruit_requests as requests
-import adafruit_esp32spi.adafruit_esp32spi_socket as socket
+import adafruit_connection_manager
+import adafruit_requests
 from adafruit_esp32spi import adafruit_esp32spi
 
 
@@ -53,7 +52,9 @@ else:
     spi = busio.SPI(board.SCK, board.MOSI, board.MISO)
 esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
-requests.set_socket(socket, esp)
+pool = adafruit_connection_manager.get_radio_socketpool(esp)
+ssl_context = adafruit_connection_manager.get_radio_ssl_context(esp)
+requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,6 @@
 # SPDX-License-Identifier: Unlicense
 
 Adafruit-Blinka
-adafruit-circuitpython-requests
 adafruit-circuitpython-busdevice
+adafruit-circuitpython-connectionmanager
+adafruit-circuitpython-requests


### PR DESCRIPTION
Remove legacy `requests.set_socket` and replace with new `pool` and `ssl_context` helpers from [ConnectionManager](https://github.com/adafruit/Adafruit_CircuitPython_ConnectionManager/)