### PR TITLE
tweak output formatting

### DIFF
--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -63,11 +63,11 @@ requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")
-print("Firmware vers.", esp.firmware_version)
-print("MAC addr:", [hex(i) for i in esp.MAC_address])
+print("Firmware vers.", esp.firmware_version.decode("utf-8"))
+print("MAC addr:", ":".join("%02X" % byte for byte in esp.MAC_address))
 
 for ap in esp.scan_networks():
-    print("\t%s\t\tRSSI: %d" % (str(ap["ssid"], "utf-8"), ap["rssi"]))
+    print("\t%-23s RSSI: %d" % (str(ap["ssid"], "utf-8"), ap["rssi"]))
 
 print("Connecting to AP...")
 while not esp.is_connected:


### PR DESCRIPTION
A few tweaks to pretty up the output formatting.

- Convert the version byte array to a utf-8 string
- display the mac address as colon separated hex byte values, instead of a list
- use a fixed width field for ssid values, so that the RSSI lines up better
  - if want to handle ssid up to the maximum 32 bytes, I suggest replacing the leading tab character with a couple of spaces.