### PR TITLE
socket.connect(): Auto-select UDP_MODE

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
@@ -121,7 +121,7 @@ class Socket:
 
     def send(self, data):
         """Send some data to the socket."""
-        if self._type is SocketPool.SOCK_DGRAM:
+        if self._type == SocketPool.SOCK_DGRAM:
             conntype = self._interface.UDP_MODE
         else:
             conntype = self._interface.TCP_MODE

--- a/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
@@ -108,7 +108,11 @@ class Socket:
         depending on the underlying interface"""
         host, port = address
         if conntype is None:
-            conntype = self._interface.TCP_MODE
+            conntype = (
+                self._interface.UDP_MODE
+                if self._type == SocketPool.SOCK_DGRAM
+                else self._interface.TCP_MODE
+            )
         if not self._interface.socket_connect(
             self._socknum, host, port, conn_mode=conntype
         ):


### PR DESCRIPTION
This improves compatibility with the standard socket module

Not tested. Prompted by https://github.com/adafruit/Adafruit_CircuitPython_NTP/pull/32