### PR TITLE
Fix SocketPoolConstants typo

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
@@ -29,7 +29,7 @@ from adafruit_esp32spi import adafruit_esp32spi as esp32spi
 _global_socketpool = {}
 
 
-class SocketPoolContants:  # pylint: disable=too-few-public-methods
+class SocketPoolConstants:  # pylint: disable=too-few-public-methods
     """Helper class for the constants that are needed everywhere"""
 
     SOCK_STREAM = const(0)
@@ -40,7 +40,7 @@ class SocketPoolContants:  # pylint: disable=too-few-public-methods
     MAX_PACKET = const(4000)
 
 
-class SocketPool(SocketPoolContants):
+class SocketPool(SocketPoolConstants):
     """ESP32SPI SocketPool library"""
 
     def __new__(cls, iface: ESP_SPIcontrol):
@@ -60,12 +60,12 @@ class SocketPool(SocketPoolContants):
         if not isinstance(port, int):
             raise ValueError("Port must be an integer")
         ipaddr = self._interface.get_host_by_name(host)
-        return [(SocketPoolContants.AF_INET, socktype, proto, "", (ipaddr, port))]
+        return [(SocketPoolConstants.AF_INET, socktype, proto, "", (ipaddr, port))]
 
     def socket(  # pylint: disable=redefined-builtin
         self,
-        family=SocketPoolContants.AF_INET,
-        type=SocketPoolContants.SOCK_STREAM,
+        family=SocketPoolConstants.AF_INET,
+        type=SocketPoolConstants.SOCK_STREAM,
         proto=0,
         fileno=None,
     ):


### PR DESCRIPTION
I can't spell. Another user found a type in [WIZnet](https://github.com/adafruit/Adafruit_CircuitPython_Wiznet5k/pull/161), so also fixing it here