### PR TITLE
Remove timeout Exception

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
@@ -21,6 +21,7 @@ except ImportError:
     pass
 
 
+import errno
 import time
 import gc
 from micropython import const
@@ -181,7 +182,7 @@ class Socket:
                 break
             # No bytes yet, or more bytes requested.
             if self._timeout > 0 and time.monotonic() - last_read_time > self._timeout:
-                raise timeout("timed out")
+                raise OSError(errno.ETIMEDOUT)
         return num_read
 
     def settimeout(self, value):
@@ -223,11 +224,3 @@ class Socket:
     def close(self):
         """Close the socket, after reading whatever remains"""
         self._interface.socket_close(self._socknum)
-
-
-class timeout(TimeoutError):  # pylint: disable=invalid-name
-    """TimeoutError class. An instance of this error will be raised by recv_into() if
-    the timeout has elapsed and we haven't received any data yet."""
-
-    def __init__(self, msg):
-        super().__init__(msg)


### PR DESCRIPTION
This removes the custom timeout Exception that makes this socket library behave like CPython versions pre 3.10 and updates it to behave like espressif and pico-w.

This should fix the issues with https://github.com/adafruit/Adafruit_CircuitPython_MiniMQTT/issues/216

If this is successful, a similar PR can be opened for the WIZnet5k, and a comment only PR for MiniMQTT to specify what devices hit which paths