### PR TITLE
Add ap_info

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -195,9 +195,7 @@ class ESP_Network:
     @property
     def country(self):
         """String id of the country code"""
-        if self._raw_country:
-            return self._raw_country
-        return None
+        return self._raw_country
 
     @property
     def authmode(self):

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -131,7 +131,7 @@ ADC_ATTEN_DB_11 = const(3)
 # pylint: disable=too-many-lines
 
 
-class ESP_Network:
+class Network:
     """A wifi network provided by a nearby access point."""
 
     def __init__(  # pylint: disable=too-many-arguments
@@ -491,7 +491,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             channel = self._send_command_get_response(_GET_IDX_CHAN_CMD, ((i,),))[0]
             authmode = self._send_command_get_response(_GET_IDX_ENCT_CMD, ((i,),))[0]
             APs.append(
-                ESP_Network(
+                Network(
                     raw_ssid=name,
                     raw_bssid=bssid,
                     raw_rssi=rssi,
@@ -608,7 +608,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         """Network object containing BSSID, SSID, authmode, channel, country and RSSI when
         connected to an access point. None otherwise."""
         if self.is_connected:
-            return ESP_Network(esp_spi_control=self)
+            return Network(esp_spi_control=self)
         return None
 
     @property

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -131,6 +131,97 @@ ADC_ATTEN_DB_11 = const(3)
 # pylint: disable=too-many-lines
 
 
+class ESP_Network:
+    """A wifi network provided by a nearby access point."""
+
+    def __init__(  # pylint: disable=too-many-arguments
+        self,
+        esp_spi_control=None,
+        raw_ssid=None,
+        raw_bssid=None,
+        raw_rssi=None,
+        raw_channel=None,
+        raw_country=None,
+        raw_authmode=None,
+    ):
+        self._esp_spi_control = esp_spi_control
+        self._raw_ssid = raw_ssid
+        self._raw_bssid = raw_bssid
+        self._raw_rssi = raw_rssi
+        self._raw_channel = raw_channel
+        self._raw_country = raw_country
+        self._raw_authmode = raw_authmode
+
+    def _get_response(self, cmd):
+        respose = self._esp_spi_control._send_command_get_response(  # pylint: disable=protected-access
+            cmd, [b"\xFF"]
+        )
+        return respose[0]
+
+    @property
+    def ssid(self):
+        """String id of the network"""
+        if self._raw_ssid:
+            response = self._raw_ssid
+        else:
+            response = self._get_response(_GET_CURR_SSID_CMD)
+        return response.decode("utf-8")
+
+    @property
+    def bssid(self):
+        """BSSID of the network (usually the AP’s MAC address)"""
+        if self._raw_bssid:
+            response = self._raw_bssid
+        else:
+            response = self._get_response(_GET_CURR_BSSID_CMD)
+        return bytes(response)
+
+    @property
+    def rssi(self):
+        """Signal strength of the network"""
+        if self._raw_bssid:
+            response = self._raw_rssi
+        else:
+            response = self._get_response(_GET_CURR_RSSI_CMD)
+        return struct.unpack("<i", response)[0]
+
+    @property
+    def channel(self):
+        """Channel number the network is operating on"""
+        if self._raw_channel:
+            return self._raw_channel[0]
+        return None
+
+    @property
+    def country(self):
+        """String id of the country code"""
+        if self._raw_country:
+            return self._raw_country
+        return None
+
+    @property
+    def authmode(self):
+        """String id of the authmode
+
+        derived from Nina code:
+        https://github.com/adafruit/nina-fw/blob/master/arduino/libraries/WiFi/src/WiFi.cpp#L385
+        """
+        if self._raw_authmode:
+            response = self._raw_authmode[0]
+        else:
+            response = self._get_response(_GET_CURR_ENCT_CMD)[0]
+
+        if response == 7:
+            return "OPEN"
+        if response == 5:
+            return "WEP"
+        if response == 2:
+            return "PSK"
+        if response == 4:
+            return "WPA2"
+        return "UNKNOWN"
+
+
 class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-instance-attributes
     """A class that will talk to an ESP32 module programmed with special firmware
     that lets it act as a fast an efficient WiFi co-processor"""
@@ -359,7 +450,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         if self._debug:
             print("Firmware version")
         resp = self._send_command_get_response(_GET_FW_VERSION_CMD)
-        return resp[0]
+        return resp[0].decode("utf-8").replace("\x00", "")
 
     @property
     def MAC_address(self):  # pylint: disable=invalid-name
@@ -397,16 +488,19 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         # print("SSID names:", names)
         APs = []  # pylint: disable=invalid-name
         for i, name in enumerate(names):
-            a_p = {"ssid": name}
-            rssi = self._send_command_get_response(_GET_IDX_RSSI_CMD, ((i,),))[0]
-            a_p["rssi"] = struct.unpack("<i", rssi)[0]
-            encr = self._send_command_get_response(_GET_IDX_ENCT_CMD, ((i,),))[0]
-            a_p["encryption"] = encr[0]
             bssid = self._send_command_get_response(_GET_IDX_BSSID_CMD, ((i,),))[0]
-            a_p["bssid"] = bssid
-            chan = self._send_command_get_response(_GET_IDX_CHAN_CMD, ((i,),))[0]
-            a_p["channel"] = chan[0]
-            APs.append(a_p)
+            rssi = self._send_command_get_response(_GET_IDX_RSSI_CMD, ((i,),))[0]
+            channel = self._send_command_get_response(_GET_IDX_CHAN_CMD, ((i,),))[0]
+            authmode = self._send_command_get_response(_GET_IDX_ENCT_CMD, ((i,),))[0]
+            APs.append(
+                ESP_Network(
+                    raw_ssid=name,
+                    raw_bssid=bssid,
+                    raw_rssi=rssi,
+                    raw_channel=channel,
+                    raw_authmode=authmode,
+                )
+            )
         return APs
 
     def scan_networks(self):
@@ -512,23 +606,12 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             raise OSError("Failed to setup AP password")
 
     @property
-    def ssid(self):
-        """The name of the access point we're connected to"""
-        resp = self._send_command_get_response(_GET_CURR_SSID_CMD, [b"\xFF"])
-        return resp[0]
-
-    @property
-    def bssid(self):
-        """The MAC-formatted service set ID of the access point we're connected to"""
-        resp = self._send_command_get_response(_GET_CURR_BSSID_CMD, [b"\xFF"])
-        return resp[0]
-
-    @property
-    def rssi(self):
-        """The receiving signal strength indicator for the access point we're
-        connected to"""
-        resp = self._send_command_get_response(_GET_CURR_RSSI_CMD, [b"\xFF"])
-        return struct.unpack("<i", resp[0])[0]
+    def ap_info(self):
+        """Network object containing BSSID, SSID, authmode, channel, country and RSSI when
+        connected to an access point. None otherwise."""
+        if self.is_connected:
+            return ESP_Network(esp_spi_control=self)
+        return None
 
     @property
     def network_data(self):
@@ -942,7 +1025,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         :param int pin: ESP32 GPIO pin to read from.
         """
         # Verify nina-fw => 1.5.0
-        fw_semver_maj = bytes(self.firmware_version).decode("utf-8")[2]
+        fw_semver_maj = self.firmware_version[2]
         assert int(fw_semver_maj) >= 5, "Please update nina-fw to 1.5.0 or above."
 
         resp = self._send_command_get_response(_SET_DIGITAL_READ_CMD, ((pin,),))[0]
@@ -961,7 +1044,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         :param int atten: attenuation constant
         """
         # Verify nina-fw => 1.5.0
-        fw_semver_maj = bytes(self.firmware_version).decode("utf-8")[2]
+        fw_semver_maj = self.firmware_version[2]
         assert int(fw_semver_maj) >= 5, "Please update nina-fw to 1.5.0 or above."
 
         resp = self._send_command_get_response(_SET_ANALOG_READ_CMD, ((pin,), (atten,)))

--- a/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_wifimanager.py
@@ -96,10 +96,7 @@ class ESPSPI_WiFiManager:
             print("Firmware vers.", self.esp.firmware_version)
             print("MAC addr:", [hex(i) for i in self.esp.MAC_address])
             for access_pt in self.esp.scan_networks():
-                print(
-                    "\t%s\t\tRSSI: %d"
-                    % (str(access_pt["ssid"], "utf-8"), access_pt["rssi"])
-                )
+                print("\t%s\t\tRSSI: %d" % (access_pt.ssid, access_pt.rssi))
         if self._connection_type == ESPSPI_WiFiManager.NORMAL:
             self.connect_normal()
         elif self._connection_type == ESPSPI_WiFiManager.ENTERPRISE:
@@ -328,7 +325,7 @@ class ESPSPI_WiFiManager:
             self.connect()
         self.pixel_status((0, 0, 100))
         self.pixel_status(0)
-        return self.esp.pretty_ip(self.esp.ip_address)
+        return self.esp.ipv4_address
 
     def pixel_status(self, value):
         """
@@ -349,4 +346,4 @@ class ESPSPI_WiFiManager:
         """
         if not self.esp.is_connected:
             self.connect()
-        return self.esp.rssi
+        return self.esp.ap_info.rssi

--- a/examples/esp32spi_ipconfig.py
+++ b/examples/esp32spi_ipconfig.py
@@ -70,7 +70,7 @@ while not esp.is_connected:
     except OSError as e:
         print("could not connect to AP, retrying: ", e)
         continue
-print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
+print("Connected to", esp.ap_info.ssid, "\tRSSI:", esp.ap_info.rssi)
 ip1 = esp.ip_address
 
 print("set ip dns")
@@ -91,9 +91,7 @@ print(
     esp.pretty_ip(info["netmask"]),
 )
 
-IP_ADDR = esp.pretty_ip(esp.ip_address)
-print("ip:", IP_ADDR)
-print("My IP address is", esp.pretty_ip(esp.ip_address))
+print("My IP address is", esp.ipv4_address)
 print("udp in addr: ", UDP_IN_ADDR, UDP_IN_PORT)
 
 socketaddr_udp_in = pool.getaddrinfo(UDP_IN_ADDR, UDP_IN_PORT)[0][4]

--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -63,11 +63,11 @@ requests = adafruit_requests.Session(pool, ssl_context)
 
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")
-print("Firmware vers.", esp.firmware_version.decode("utf-8"))
+print("Firmware vers.", esp.firmware_version)
 print("MAC addr:", ":".join("%02X" % byte for byte in esp.MAC_address))
 
 for ap in esp.scan_networks():
-    print("\t%-23s RSSI: %d" % (str(ap["ssid"], "utf-8"), ap["rssi"]))
+    print("\t%-23s RSSI: %d" % (ap.ssid, ap.rssi))
 
 print("Connecting to AP...")
 while not esp.is_connected:
@@ -76,8 +76,8 @@ while not esp.is_connected:
     except OSError as e:
         print("could not connect to AP, retrying: ", e)
         continue
-print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
-print("My IP address is", esp.pretty_ip(esp.ip_address))
+print("Connected to", esp.ap_info.ssid, "\tRSSI:", esp.ap_info.rssi)
+print("My IP address is", esp.ipv4_address)
 print(
     "IP lookup adafruit.com: %s" % esp.pretty_ip(esp.get_host_by_name("adafruit.com"))
 )

--- a/examples/esp32spi_simpletest_rp2040.py
+++ b/examples/esp32spi_simpletest_rp2040.py
@@ -46,7 +46,7 @@ print("Firmware vers.", esp.firmware_version)
 print("MAC addr:", [hex(i) for i in esp.MAC_address])
 
 for ap in esp.scan_networks():
-    print("\t%s\t\tRSSI: %d" % (str(ap["ssid"], "utf-8"), ap["rssi"]))
+    print("\t%s\t\tRSSI: %d" % (ap.ssid, ap.rssi))
 
 print("Connecting to AP...")
 while not esp.is_connected:
@@ -55,8 +55,8 @@ while not esp.is_connected:
     except OSError as e:
         print("could not connect to AP, retrying: ", e)
         continue
-print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
-print("My IP address is", esp.pretty_ip(esp.ip_address))
+print("Connected to", esp.ap_info.ssid, "\tRSSI:", esp.ap_info.rssi)
+print("My IP address is", esp.ipv4_address)
 print(
     "IP lookup adafruit.com: %s" % esp.pretty_ip(esp.get_host_by_name("adafruit.com"))
 )

--- a/examples/esp32spi_wpa2ent_simpletest.py
+++ b/examples/esp32spi_wpa2ent_simpletest.py
@@ -59,17 +59,15 @@ requests = adafruit_requests.Session(pool, ssl_context)
 if esp.status == adafruit_esp32spi.WL_IDLE_STATUS:
     print("ESP32 found and in idle mode")
 
-# Get the ESP32 fw version number, remove trailing byte off the returned bytearray
-# and then convert it to a string for prettier printing and later comparison
-firmware_version = "".join([chr(b) for b in esp.firmware_version[:-1]])
-print("Firmware vers.", firmware_version)
+# Get the ESP32 fw version number
+print("Firmware vers.", esp.firmware_version)
 
 print("MAC addr:", [hex(i) for i in esp.MAC_address])
 
 # WPA2 Enterprise support was added in fw ver 1.3.0. Check that the ESP32
 # is running at least that version, otherwise, bail out
 assert (
-    version_compare(firmware_version, "1.3.0") >= 0
+    version_compare(esp.firmware_version, "1.3.0") >= 0
 ), "Incorrect ESP32 firmware version; >= 1.3.0 required."
 
 # Set up the SSID you would like to connect to
@@ -98,8 +96,8 @@ while not esp.is_connected:
     time.sleep(2)
 
 print("")
-print("Connected to", str(esp.ssid, "utf-8"), "\tRSSI:", esp.rssi)
-print("My IP address is", esp.pretty_ip(esp.ip_address))
+print("Connected to", esp.ap_info.ssid, "\tRSSI:", esp.ap_info.rssi)
+print("My IP address is", esp.ipv4_address)
 print(
     "IP lookup adafruit.com: %s" % esp.pretty_ip(esp.get_host_by_name("adafruit.com"))
 )

--- a/examples/gpio/esp32spi_gpio.py
+++ b/examples/gpio/esp32spi_gpio.py
@@ -67,11 +67,7 @@ esp = adafruit_esp32spi.ESP_SPIcontrol(spi, esp32_cs, esp32_ready, esp32_reset)
 
 esp_reset_all()
 
-espfirmware = ""
-for _ in esp.firmware_version:
-    if _ != 0:
-        espfirmware += "{:c}".format(_)
-print("ESP32 Firmware:", espfirmware)
+print("ESP32 Firmware:", esp.firmware_version)
 
 print(
     "ESP32 MAC:      {5:02X}:{4:02X}:{3:02X}:{2:02X}:{1:02X}:{0:02X}".format(


### PR DESCRIPTION
This moves `ssid`, `bssid` and `rssi` to a new network class to match `wifi.radio`. Also added in `authmode` since the call was there, but not being used.

Also made `firmware_version` a string, since it always needs to be formated.

Once Approved, will open PRs examples in other libraries and guides.