### PR TITLE
Really, really remove wsgi

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
       - id: end-of-file-fixer
       - id: trailing-whitespace
   - repo: https://github.com/pycqa/pylint
-    rev: v2.17.4
+    rev: v3.3.1
     hooks:
       - id: pylint
         name: pylint (library code)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
         name: pylint (library code)
         types: [python]
         args:
-          - --disable=consider-using-f-string
+          - --disable=consider-using-f-string,too-many-arguments,too-many-positional-arguments
         exclude: "^(docs/|examples/|tests/|setup.py$)"
       - id: pylint
         name: pylint (example code)

--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -416,7 +416,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             print("Read %d: " % len(responses[0]), responses)
         return responses
 
-    def _send_command_get_response(
+    def _send_command_get_response(  # pylint: disable=too-many-arguments
         self,
         cmd,
         params=None,

--- a/examples/server/esp32spi_wsgiserver.py
+++ b/examples/server/esp32spi_wsgiserver.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2024 Dan Halbert for Adafruit Industries
+# SPDX-License-Identifier: MIT
+# will be empty


### PR DESCRIPTION
#181 did not actually remove `adafruit_esp32spi_wsgiserver.py`
Update pylint and handle new complaints

EDIT: we cannot seem to delete an empty. Add it as non-empty here. Then we'll remove it.