### PR TITLE
Use adafruit-hosted sample JSON URL

### DIFF
--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -26,7 +26,7 @@ if secrets == {"ssid": None, "password": None}:
 print("ESP32 SPI webclient test")
 
 TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
-JSON_URL = "http://api.coindesk.com/v1/bpi/currentprice/USD.json"
+JSON_URL = "http://wifitest.adafruit.com/testwifi/sample.json"
 
 
 # If you are using a board with pre-defined ESP32 Pins:

--- a/examples/esp32spi_simpletest_rp2040.py
+++ b/examples/esp32spi_simpletest_rp2040.py
@@ -26,7 +26,7 @@ if secrets == {"ssid": None, "password": None}:
 print("Raspberry Pi RP2040 - ESP32 SPI webclient test")
 
 TEXT_URL = "http://wifitest.adafruit.com/testwifi/index.html"
-JSON_URL = "http://api.coindesk.com/v1/bpi/currentprice/USD.json"
+JSON_URL = "http://wifitest.adafruit.com/testwifi/sample.json"
 
 # Raspberry Pi RP2040 Pinout
 esp32_cs = DigitalInOut(board.GP13)


### PR DESCRIPTION
The sample HTTP JSON URL in a couple of tests was on http://api.coindesk.com, which doesn't exist anymore. Instead, use the (newly added) URL: http://wifitest.adafruit.com/testwifi/sample.json.

Tested on a Metro M4 AirLift Lite.

The examples are used on Learn Guide pages, so a quick review would be good, since right now the examples are broken.