### PR TITLE
Bring more compatibility with native sockets

### DIFF
--- a/adafruit_esp32spi/adafruit_esp32spi.py
+++ b/adafruit_esp32spi/adafruit_esp32spi.py
@@ -844,7 +844,8 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         return self.socket_status(socket_num) == SOCKET_ESTABLISHED
 
     def socket_write(self, socket_num, buffer, conn_mode=TCP_MODE):
-        """Write the bytearray buffer to a socket"""
+        """Write the bytearray buffer to a socket.
+        Returns the number of bytes written"""
         if self._debug:
             print("Writing:", buffer)
         self._socknum_ll[0][0] = socket_num
@@ -874,7 +875,7 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
             resp = self._send_command_get_response(_SEND_UDP_DATA_CMD, self._socknum_ll)
             if resp[0][0] != 1:
                 raise ConnectionError("Failed to send UDP data")
-            return
+            return sent
 
         if sent != len(buffer):
             self.socket_close(socket_num)
@@ -885,6 +886,8 @@ class ESP_SPIcontrol:  # pylint: disable=too-many-public-methods, too-many-insta
         resp = self._send_command_get_response(_DATA_SENT_TCP_CMD, self._socknum_ll)
         if resp[0][0] != 1:
             raise ConnectionError("Failed to verify data sent")
+
+        return sent
 
     def socket_available(self, socket_num):
         """Determine how many bytes are waiting to be read on the socket"""

--- a/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
@@ -76,7 +76,13 @@ class SocketPool:
 
 class Socket:
     """A simplified implementation of the Python 'socket' class, for connecting
-    through an interface to a remote device"""
+    through an interface to a remote device. Has properties specific to the
+    implementation.
+
+    :param SocketPool socket_pool: The underlying socket pool.
+    :param Optional[int] socknum: Allows wrapping a Socket instance around a socket
+                              number returned by the nina firmware. Used internally.
+    """
 
     def __init__(  # pylint: disable=redefined-builtin,too-many-arguments,unused-argument
         self,

--- a/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
+++ b/adafruit_esp32spi/adafruit_esp32spi_socketpool.py
@@ -254,31 +254,6 @@ class Socket:
     # WORK IN PROGRESS
     ####################################################################
 
-    def setsockopt(self, *opts, **kwopts):
-        """Dummy call for compatibility."""
-
-    def setblocking(self, flag: bool):
-        """Set the blocking behaviour of this socket.
-        :param bool flag: False means non-blocking, True means block indefinitely.
-        """
-        if flag:
-            self.settimeout(None)
-        else:
-            self.settimeout(0)
-
-    def bind(self, address: Tuple[str, int]):
-        """Bind a socket to an address"""
-        self._bound = address
-
-    def listen(self, backlog: int):  # pylint: disable=unused-argument
-        """Set socket to listen for incoming connections.
-        :param int backlog: length of backlog queue for waiting connections (ignored)
-        """
-        if not self._bound:
-            self._bound = (self._interface.ip_address, 80)
-        port = self._bound[1]
-        self._interface.start_server(port, self._socknum)
-
     def accept(self):
         """Accept a connection on a listening socket of type SOCK_STREAM,
         creating a new socket of type SOCK_STREAM. Returns a tuple of
@@ -294,3 +269,28 @@ class Socket:
             client_address = (ip_address, port)
             return sock, client_address
         raise OSError(errno.ECONNRESET)
+
+    def bind(self, address: Tuple[str, int]):
+        """Bind a socket to an address"""
+        self._bound = address
+
+    def listen(self, backlog: int):  # pylint: disable=unused-argument
+        """Set socket to listen for incoming connections.
+        :param int backlog: length of backlog queue for waiting connections (ignored)
+        """
+        if not self._bound:
+            self._bound = (self._interface.ip_address, 80)
+        port = self._bound[1]
+        self._interface.start_server(port, self._socknum)
+
+    def setblocking(self, flag: bool):
+        """Set the blocking behaviour of this socket.
+        :param bool flag: False means non-blocking, True means block indefinitely.
+        """
+        if flag:
+            self.settimeout(None)
+        else:
+            self.settimeout(0)
+
+    def setsockopt(self, *opts, **kwopts):
+        """Dummy call for compatibility."""


### PR DESCRIPTION
This PR adds methods to socketpool and socket to make it more compatible with the native socketpool and sockets. This was specifically made to make it work with `adafruit_httpserver`, which it does, **once the httpserver library is changed to not import `ssl` unconditionally**.

A breaking change was made to the socket's `settimeout()`, by copying the core API, which also matches the python API: `None` blocks, `0` doesn't. Previously this library did the opposite. I don't know what code out there is impacted by this. Maybe this should be investigated a bit before validating the PR.

https://docs.python.org/3/library/socket.html#socket.socket.settimeout
https://docs.circuitpython.org/en/latest/shared-bindings/socketpool/index.html#socketpool.Socket.settimeout

Added missing methods from Socket:
- `bind` just saves the address/port parameter
- `listen` uses the ninafw `start_server()`
- `accept` gets a client socket from the server (if any)
- `setblocking` is a shortcut for settimeout() with the appropriate values (`True` -> `None`, `False` -> `0`)
- `setsockopt` currently does nothing

Changes had to be made to the ESP32SPI library:
- re-add the `socknum` argument to the `Socket()` constructor. It's not in the python socket API, but we need to be able to wrap a Socket object around a socket number returned by ninafw when getting a client connection to the server.
- `ESP_SPIcontrol.socket_write` returns the number of bytes written, so that:
- `Socket.send` now returns the number of bytes written (as does sendto) to match the python socket() API.
- `SOL_SOCKET` and `SO_REUSEADDR` have been added to SocketPool.

The PR was tested on a Matrix Portal M4 with a modified version of `adafruit_httpserver`.