### PR TITLE
revert examples to old API

### DIFF
--- a/examples/esp32spi_aio_post.py
+++ b/examples/esp32spi_aio_post.py
@@ -9,8 +9,12 @@ import busio
 import neopixel
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
-from adafruit_esp32spi.wifimanager import WiFiManager
+# Use these imports for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+# from adafruit_esp32spi.wifimanager import WiFiManager
+from adafruit_esp32spi import adafruit_esp32spi
+from adafruit_esp32spi.adafruit_esp32spi_wifimanager import WiFiManager
 
 print("ESP32 SPI webclient test")
 

--- a/examples/esp32spi_cheerlights.py
+++ b/examples/esp32spi_cheerlights.py
@@ -10,8 +10,12 @@ import busio
 import neopixel
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
-from adafruit_esp32spi.wifimanager import WiFiManager
+# Use these imports for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+# from adafruit_esp32spi.wifimanager import WiFiManager
+from adafruit_esp32spi import adafruit_esp32spi
+from adafruit_esp32spi.adafruit_esp32spi_wifimanager import WiFiManager
 
 # Get wifi details and more from a settings.toml file
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD

--- a/examples/esp32spi_ipconfig.py
+++ b/examples/esp32spi_ipconfig.py
@@ -8,8 +8,12 @@ import board
 import busio
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
-from adafruit_esp32spi import socketpool
+# Use these imports for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+# from adafruit_esp32spi import socketpool
+import adafruit_esp32spi.adafruit_esp32spi_socketpool as socketpool
+from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a settings.toml file
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD

--- a/examples/esp32spi_localtime.py
+++ b/examples/esp32spi_localtime.py
@@ -10,8 +10,12 @@ import neopixel
 import rtc
 from digitalio import DigitalInOut
 
-adafruit_esp32spi
-from adafruit_esp32spi.wifimanager import WiFiManager
+# Use these imports for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+# from adafruit_esp32spi.wifimanager import WiFiManager
+from adafruit_esp32spi import adafruit_esp32spi
+from adafruit_esp32spi.adafruit_esp32spi_wifimanager import WiFiManager
 
 # Get wifi details and more from a settings.toml file
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD

--- a/examples/esp32spi_simpletest.py
+++ b/examples/esp32spi_simpletest.py
@@ -9,7 +9,10 @@ import board
 import busio
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
+# Use this import for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a settings.toml file
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD

--- a/examples/esp32spi_simpletest_rp2040.py
+++ b/examples/esp32spi_simpletest_rp2040.py
@@ -9,7 +9,10 @@ import board
 import busio
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
+# Use this import for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a settings.toml file
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD

--- a/examples/esp32spi_tcp_client.py
+++ b/examples/esp32spi_tcp_client.py
@@ -7,8 +7,12 @@ import board
 import busio
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
-from adafruit_esp32spi import socketpool
+# Use these imports for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+# from adafruit_esp32spi import socketpool
+import adafruit_esp32spi.adafruit_esp32spi_socketpool as socketpool
+from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a settings.toml file
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD

--- a/examples/esp32spi_udp_client.py
+++ b/examples/esp32spi_udp_client.py
@@ -9,8 +9,12 @@ import board
 import busio
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
-from adafruit_esp32spi import socketpool
+# Use these imports for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+# from adafruit_esp32spi import socketpool
+import adafruit_esp32spi.adafruit_esp32spi_socketpool as socketpool
+from adafruit_esp32spi import adafruit_esp32spi
 
 # Get wifi details and more from a settings.toml file
 # tokens used by this Demo: CIRCUITPY_WIFI_SSID, CIRCUITPY_WIFI_PASSWORD

--- a/examples/esp32spi_wpa2ent_aio_post.py
+++ b/examples/esp32spi_wpa2ent_aio_post.py
@@ -9,8 +9,12 @@ import busio
 import neopixel
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
-from adafruit_esp32spi.wifimanager import WiFiManager
+# Use this import for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+# from adafruit_esp32spi.wifimanager import WiFiManager
+from adafruit_esp32spi import adafruit_esp32spi
+from adafruit_esp32spi.adafruit_esp32spi_wifimanager import WiFiManager
 
 print("ESP32 SPI WPA2 Enterprise webclient test")
 

--- a/examples/esp32spi_wpa2ent_simpletest.py
+++ b/examples/esp32spi_wpa2ent_simpletest.py
@@ -18,7 +18,10 @@ import board
 import busio
 from digitalio import DigitalInOut
 
-import adafruit_esp32spi
+# Use this import for adafruit_esp32spi version 11.0.0 and up.
+# Note that frozen libraries may not be up to date.
+# import adafruit_esp32spi
+from adafruit_esp32spi import adafruit_esp32spi
 
 
 # Version number comparison code. Credit to gnud on stackoverflow


### PR DESCRIPTION
I changed the examples to the new API, but they don't work on 10.0.3 or earlier boards with the older frozen library. Revert those changes for now, until 10.1.0 with updated frozen versions in released.

Also there was a typo (missing `import `) in ` examples/esp32spi_localtime.py`.