### PR TITLE
TIME API URL change

### DIFF
--- a/examples/esp32spi_localtime.py
+++ b/examples/esp32spi_localtime.py
@@ -24,7 +24,7 @@ password = getenv("CIRCUITPY_WIFI_PASSWORD")
 
 print("ESP32 local time")
 
-TIME_API = "http://worldtimeapi.org/api/ip"
+TIME_API = "https://time.now/developer/api/ip"
 
 # If you are using a board with pre-defined ESP32 Pins:
 esp32_cs = DigitalInOut(board.ESP_CS)


### PR DESCRIPTION
Various guides and example code reference this http time setting website.

```
http://worldtimeapi.org/api/ip
```

It is no longer available. This PR is a one line change that switches to:

```
https://time.now/developer/api/ip
```

Unless there is another preferred source we should probably change this across the guides and github repos. 


```
Adafruit CircuitPython 10.1.1 on 2026-02-17; Adafruit Matrix Portal M4 with samd51j19
>>>
soft reboot

Auto-reload is on. Simply save files over USB to run them or enter REPL to disable.
code.py output:
ESP32 local time
Fetching json from https://time.now/developer/api/ip
struct_time(tm_year=2026, tm_mon=2, tm_mday=18, tm_hour=12, tm_min=31, tm_sec=47, tm_wday=3, tm_yday=49, tm_isdst=False)
```

[forum issue](https://forums.adafruit.com/viewtopic.php?t=222520)